### PR TITLE
fix(supabase): support PostgreSQL 17 migrations

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -22,7 +22,7 @@ port = 54322
 shadow_port = 54320
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 15
+major_version = 17
 
 [db.pooler]
 enabled = false

--- a/supabase/migrations/20231219145602_remote_schema.sql
+++ b/supabase/migrations/20231219145602_remote_schema.sql
@@ -10,8 +10,6 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
-CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
-
 ALTER SCHEMA "public" OWNER TO "postgres";
 
 CREATE EXTENSION IF NOT EXISTS "pg_graphql" WITH SCHEMA "graphql";
@@ -19,8 +17,6 @@ CREATE EXTENSION IF NOT EXISTS "pg_graphql" WITH SCHEMA "graphql";
 CREATE EXTENSION IF NOT EXISTS "pg_stat_statements" WITH SCHEMA "extensions";
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "extensions";
-
-CREATE EXTENSION IF NOT EXISTS "pgjwt" WITH SCHEMA "extensions";
 
 CREATE EXTENSION IF NOT EXISTS "supabase_vault" WITH SCHEMA "vault";
 


### PR DESCRIPTION
## Résumé
- retire les extensions historiques `pgsodium` et `pgjwt`, absentes ou dépréciées sur PostgreSQL 17
- aligne la configuration locale Supabase sur PostgreSQL 17

## Validation
- `git diff --check`
- validation complète des migrations par Supabase Preview