### PR TITLE
Add AI feature request intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-feature.yml
+++ b/.github/ISSUE_TEMPLATE/ai-feature.yml
@@ -1,0 +1,102 @@
+name: Fonctionnalité assistée par IA
+description: Décrire une fonctionnalité qui sera spécifiée puis développée par les agents Synupsis.
+title: "[Feature IA] "
+labels:
+  - "ai:request"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!-- synupsis-ai-request:v1 -->
+        Décris le besoin avec tes mots. Tu n'as pas besoin de proposer une solution technique : les agents s'en chargeront.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problème à résoudre
+      description: Quel problème rencontres-tu aujourd'hui et pourquoi est-il important ?
+      placeholder: Aujourd'hui, un utilisateur ne peut pas…
+    validations:
+      required: true
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Utilisateurs concernés
+      description: Qui bénéficiera principalement de cette fonctionnalité ?
+      options:
+        - Visiteurs non connectés
+        - Utilisateurs connectés
+        - Administrateurs
+        - Tous les utilisateurs
+        - Je ne sais pas encore
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Résultat attendu
+      description: Que devrait-il se passer une fois la fonctionnalité terminée ?
+      placeholder: L'utilisateur peut…
+    validations:
+      required: true
+
+  - type: textarea
+    id: journey
+    attributes:
+      label: Parcours utilisateur imaginé
+      description: Décris les étapes principales, même approximativement.
+      placeholder: |
+        1. L'utilisateur ouvre…
+        2. Il clique sur…
+        3. Il voit…
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Critères de validation
+      description: Comment sauras-tu que le résultat te convient ? Écris une liste de comportements observables.
+      placeholder: |
+        - [ ] Le bouton est visible sur…
+        - [ ] Après le clic…
+        - [ ] En cas d'erreur…
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-impact
+    attributes:
+      label: Impact possible sur les données
+      description: La fonctionnalité semble-t-elle nécessiter de nouvelles données ou modifier la base ?
+      options:
+        - Je ne sais pas
+        - Aucun changement de données
+        - De nouvelles données seront probablement nécessaires
+        - Des données existantes seront probablement modifiées
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Contraintes et éléments à préserver
+      description: Facultatif — comportement existant, design, compatibilité ou règle métier à ne pas casser.
+      placeholder: Il faut conserver…
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Références utiles
+      description: Facultatif — captures d'écran, liens, exemples ou produits similaires.
+      placeholder: Tu peux glisser-déposer des captures d'écran ici.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: J'ai décrit le résultat attendu et j'accepte qu'une première version soit proposée sur un environnement de preview.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/scripts/feature-request-intake.mjs
+++ b/.github/scripts/feature-request-intake.mjs
@@ -1,0 +1,265 @@
+const REQUEST_MARKER = '<!-- synupsis-ai-request:v1 -->'
+const COMMENT_MARKER = '<!-- synupsis-ai-intake:v1 -->'
+
+const FIELD_DEFINITIONS = [
+  { key: 'problem', heading: 'Problème à résoudre', required: true },
+  { key: 'audience', heading: 'Utilisateurs concernés', required: true },
+  { key: 'outcome', heading: 'Résultat attendu', required: true },
+  { key: 'journey', heading: 'Parcours utilisateur imaginé', required: true },
+  { key: 'acceptance', heading: 'Critères de validation', required: true },
+  { key: 'dataImpact', heading: 'Impact possible sur les données', required: true },
+  { key: 'constraints', heading: 'Contraintes et éléments à préserver', required: false },
+  { key: 'references', heading: 'Références utiles', required: false },
+]
+
+const LABELS = {
+  request: {
+    name: 'ai:request',
+    color: '8250df',
+    description: 'Demande destinée au pipeline IA Synupsis',
+  },
+  ready: {
+    name: 'ai:ready-for-spec',
+    color: '1f883d',
+    description: 'Demande complète et prête pour l’agent de spécification',
+  },
+  needsInfo: {
+    name: 'ai:needs-info',
+    color: 'bf8700',
+    description: 'Informations manquantes avant la spécification',
+  },
+  needsApproval: {
+    name: 'ai:needs-approval',
+    color: 'cf222e',
+    description: 'Demande externe nécessitant l’accord d’un mainteneur',
+  },
+}
+
+const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
+const EMPTY_RESPONSES = new Set(['', '_No response_'])
+
+function cleanResponse(value = '') {
+  const cleaned = value.trim()
+  return EMPTY_RESPONSES.has(cleaned) ? '' : cleaned
+}
+
+export function parseSections(body = '') {
+  const sections = new Map()
+  const lines = body.replace(/\r\n/g, '\n').split('\n')
+  let currentHeading = null
+  let currentLines = []
+
+  const flush = () => {
+    if (currentHeading) {
+      sections.set(currentHeading, cleanResponse(currentLines.join('\n')))
+    }
+  }
+
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      flush()
+      currentHeading = line.slice(4).trim()
+      currentLines = []
+      continue
+    }
+
+    if (currentHeading) {
+      currentLines.push(line)
+    }
+  }
+
+  flush()
+  return sections
+}
+
+export function normalizeFeatureRequest(body = '') {
+  const sections = parseSections(body)
+
+  return Object.fromEntries(
+    FIELD_DEFINITIONS.map(({ key, heading }) => [key, sections.get(heading) ?? '']),
+  )
+}
+
+export function validateFeatureRequest(featureRequest) {
+  return FIELD_DEFINITIONS
+    .filter(({ key, required }) => required && !featureRequest[key])
+    .map(({ heading }) => heading)
+}
+
+export function isTrustedAssociation(association = '') {
+  return TRUSTED_ASSOCIATIONS.has(association.toUpperCase())
+}
+
+function blockquote(value) {
+  const safeValue = (value || 'Non précisé')
+    .slice(0, 6000)
+    .replaceAll('@', '@\u200b')
+
+  return safeValue
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')
+}
+
+export function buildNormalizedBrief(featureRequest) {
+  return [
+    '<details>',
+    '<summary>Brief initial normalisé</summary>',
+    '',
+    '#### Problème',
+    blockquote(featureRequest.problem),
+    '',
+    '#### Utilisateurs concernés',
+    blockquote(featureRequest.audience),
+    '',
+    '#### Résultat attendu',
+    blockquote(featureRequest.outcome),
+    '',
+    '#### Parcours utilisateur',
+    blockquote(featureRequest.journey),
+    '',
+    '#### Critères de validation',
+    blockquote(featureRequest.acceptance),
+    '',
+    '#### Impact possible sur les données',
+    blockquote(featureRequest.dataImpact),
+    '',
+    '#### Contraintes',
+    blockquote(featureRequest.constraints),
+    '',
+    '#### Références',
+    blockquote(featureRequest.references),
+    '',
+    '</details>',
+  ].join('\n')
+}
+
+export function buildStatusComment({ featureRequest, missingFields, trusted }) {
+  if (!trusted) {
+    return [
+      COMMENT_MARKER,
+      '### Demande en attente d’approbation',
+      '',
+      'Cette demande provient d’un compte externe au dépôt. Un mainteneur doit la valider avant qu’un agent puisse être déclenché.',
+    ].join('\n')
+  }
+
+  if (missingFields.length > 0) {
+    return [
+      COMMENT_MARKER,
+      '### Informations complémentaires nécessaires',
+      '',
+      'Complète les sections suivantes pour rendre la demande exploitable :',
+      '',
+      ...missingFields.map((field) => `- ${field}`),
+      '',
+      'Le statut sera recalculé automatiquement après modification de l’Issue.',
+    ].join('\n')
+  }
+
+  return [
+    COMMENT_MARKER,
+    '### Demande prête pour spécification',
+    '',
+    'Le besoin est suffisamment structuré pour être transmis au futur agent de spécification. Aucun code ni déploiement n’est déclenché à cette étape.',
+    '',
+    buildNormalizedBrief(featureRequest),
+  ].join('\n')
+}
+
+async function ensureLabel(github, owner, repo, label) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: label.name })
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error
+    }
+
+    try {
+      await github.rest.issues.createLabel({ owner, repo, ...label })
+    } catch (createError) {
+      // Another simultaneous run may have created the label first.
+      if (createError.status !== 422) {
+        throw createError
+      }
+    }
+  }
+}
+
+export async function handleFeatureRequest({ github, context, core }) {
+  const issue = context.payload.issue
+
+  if (!issue || !issue.body?.includes(REQUEST_MARKER)) {
+    core.info('This issue is not a Synupsis AI feature request.')
+    return
+  }
+
+  const { owner, repo } = context.repo
+  const issueNumber = issue.number
+  const featureRequest = normalizeFeatureRequest(issue.body)
+  const missingFields = validateFeatureRequest(featureRequest)
+  const trusted = isTrustedAssociation(issue.author_association)
+  const statusLabel = !trusted
+    ? LABELS.needsApproval
+    : missingFields.length > 0
+      ? LABELS.needsInfo
+      : LABELS.ready
+
+  const managedLabels = [LABELS.request, LABELS.ready, LABELS.needsInfo, LABELS.needsApproval]
+  await Promise.all(managedLabels.map((label) => ensureLabel(github, owner, repo, label)))
+
+  const currentLabels = new Set(
+    issue.labels
+      .map((label) => typeof label === 'string' ? label : label.name)
+      .filter(Boolean),
+  )
+  const desiredLabels = new Set([LABELS.request.name, statusLabel.name])
+
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [...desiredLabels],
+  })
+
+  for (const label of managedLabels) {
+    if (currentLabels.has(label.name) && !desiredLabels.has(label.name)) {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        name: label.name,
+      })
+    }
+  }
+
+  const body = buildStatusComment({ featureRequest, missingFields, trusted })
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })
+  const previousComment = comments.find((comment) =>
+    comment.user?.type === 'Bot' && comment.body?.includes(COMMENT_MARKER),
+  )
+
+  if (previousComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: previousComment.id,
+      body,
+    })
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body,
+    })
+  }
+
+  core.setOutput('intake-status', statusLabel.name)
+  core.info(`Feature request #${issueNumber} classified as ${statusLabel.name}.`)
+}

--- a/.github/scripts/feature-request-intake.test.mjs
+++ b/.github/scripts/feature-request-intake.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildNormalizedBrief,
+  buildStatusComment,
+  handleFeatureRequest,
+  isTrustedAssociation,
+  normalizeFeatureRequest,
+  parseSections,
+  validateFeatureRequest,
+} from './feature-request-intake.mjs'
+
+const completeBody = `<!-- synupsis-ai-request:v1 -->
+### Problème à résoudre
+
+Les utilisateurs perdent leur progression.
+
+### Utilisateurs concernés
+
+Utilisateurs connectés
+
+### Résultat attendu
+
+Reprendre une story au bon endroit.
+
+### Parcours utilisateur imaginé
+
+1. Ouvrir un récap
+2. Continuer la lecture
+
+### Critères de validation
+
+- [ ] La progression est mémorisée
+
+### Impact possible sur les données
+
+De nouvelles données seront probablement nécessaires
+
+### Contraintes et éléments à préserver
+
+Le visionnage anonyme doit continuer à fonctionner.
+
+### Références utiles
+
+_No response_
+`
+
+test('parseSections supports GitHub Issue Form markdown', () => {
+  const sections = parseSections(completeBody)
+
+  assert.equal(sections.get('Problème à résoudre'), 'Les utilisateurs perdent leur progression.')
+  assert.equal(sections.get('Références utiles'), '')
+})
+
+test('normalizeFeatureRequest returns a stable agent-facing shape', () => {
+  const request = normalizeFeatureRequest(completeBody)
+
+  assert.equal(request.audience, 'Utilisateurs connectés')
+  assert.match(request.acceptance, /progression est mémorisée/)
+  assert.equal(request.references, '')
+  assert.deepEqual(validateFeatureRequest(request), [])
+})
+
+test('validateFeatureRequest lists sections removed during an edit', () => {
+  const request = normalizeFeatureRequest(completeBody.replace('Reprendre une story au bon endroit.', ''))
+
+  assert.deepEqual(validateFeatureRequest(request), ['Résultat attendu'])
+})
+
+test('only repository owners, members and collaborators are trusted', () => {
+  assert.equal(isTrustedAssociation('OWNER'), true)
+  assert.equal(isTrustedAssociation('member'), true)
+  assert.equal(isTrustedAssociation('COLLABORATOR'), true)
+  assert.equal(isTrustedAssociation('CONTRIBUTOR'), false)
+  assert.equal(isTrustedAssociation('NONE'), false)
+})
+
+test('ready comments contain the normalized brief without live mentions', () => {
+  const request = normalizeFeatureRequest(completeBody.replace('Les utilisateurs', '@product Les utilisateurs'))
+  const brief = buildNormalizedBrief(request)
+  const comment = buildStatusComment({ featureRequest: request, missingFields: [], trusted: true })
+
+  assert.match(comment, /Demande prête pour spécification/)
+  assert.match(brief, /Brief initial normalisé/)
+  assert.equal(brief.includes('@product'), false)
+  assert.equal(brief.includes('@\u200bproduct'), true)
+})
+
+test('untrusted requests require approval and do not echo their content', () => {
+  const request = normalizeFeatureRequest(completeBody)
+  const comment = buildStatusComment({ featureRequest: request, missingFields: [], trusted: false })
+
+  assert.match(comment, /attente d’approbation/)
+  assert.equal(comment.includes(request.problem), false)
+})
+
+test('handleFeatureRequest creates labels and one reusable status comment', async () => {
+  const createdLabels = []
+  const addedLabels = []
+  const comments = []
+  const outputs = new Map()
+  const github = {
+    rest: {
+      issues: {
+        getLabel: async () => {
+          const error = new Error('Not found')
+          error.status = 404
+          throw error
+        },
+        createLabel: async (label) => createdLabels.push(label.name),
+        addLabels: async ({ labels }) => addedLabels.push(...labels),
+        removeLabel: async () => {},
+        listComments: async () => {},
+        createComment: async ({ body }) => comments.push(body),
+        updateComment: async () => {},
+      },
+    },
+    paginate: async () => [],
+  }
+  const context = {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: {
+        number: 42,
+        body: completeBody,
+        author_association: 'MEMBER',
+        labels: [],
+      },
+    },
+  }
+  const core = {
+    info: () => {},
+    setOutput: (name, value) => outputs.set(name, value),
+  }
+
+  await handleFeatureRequest({ github, context, core })
+
+  assert.equal(createdLabels.length, 4)
+  assert.deepEqual(addedLabels.sort(), ['ai:ready-for-spec', 'ai:request'])
+  assert.equal(comments.length, 1)
+  assert.match(comments[0], /Demande prête pour spécification/)
+  assert.equal(outputs.get('intake-status'), 'ai:ready-for-spec')
+})

--- a/.github/workflows/ai-feature-intake.yml
+++ b/.github/workflows/ai-feature-intake.yml
@@ -1,0 +1,40 @@
+name: AI feature intake
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ai-feature-intake-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  normalize:
+    name: Validate and normalize the request
+    if: contains(github.event.issue.body, '<!-- synupsis-ai-request:v1 -->')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Classify the feature request
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/feature-request-intake.mjs`,
+            )
+            const { handleFeatureRequest } = await import(moduleUrl.href)
+            await handleFeatureRequest({ github, context, core })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
+      - name: Pipeline tests
+        run: yarn test:pipeline
+
       - name: Build
         run: yarn build

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Run Edge Functions locally
 
 ## Deployment
 
-Nuxt web client deployment is automatic on commit on _main_ branch.
+The `develop` branch is automatically deployed to the shared development environment on Netlify. Pull requests get an isolated Netlify Deploy Preview.
+
+## AI feature pipeline
+
+Non-technical contributors can submit a structured feature request from the **Fonctionnalité assistée par IA** GitHub Issue form. The current intake validates and normalizes the request before it is sent to an agent.
+
+See [the AI pipeline documentation](docs/ai-pipeline.md) for its current status and safety rules.
 
 To deploy Supabase Edge Functions run
 

--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -1,0 +1,43 @@
+# Pipeline IA Synupsis
+
+Le pipeline doit permettre à un membre non développeur de proposer une fonctionnalité, d’obtenir une preview testable, puis de demander sa mise en production sans manipuler le code.
+
+## Étape 1 — Collecte de la demande
+
+Cette première étape est disponible depuis **GitHub → Issues → New issue → Fonctionnalité assistée par IA**.
+
+Le formulaire demande :
+
+- le problème à résoudre ;
+- les utilisateurs concernés ;
+- le résultat et le parcours attendus ;
+- des critères de validation observables ;
+- l’impact probable sur les données ;
+- les contraintes et références éventuelles.
+
+À la création ou à la modification de l’Issue, le workflow `AI feature intake` :
+
+1. vérifie que les champs indispensables sont présents ;
+2. vérifie que l’auteur est propriétaire, membre ou collaborateur du dépôt ;
+3. transforme les réponses en brief initial normalisé ;
+4. maintient un commentaire de statut unique sur l’Issue ;
+5. applique l’un des labels suivants :
+   - `ai:ready-for-spec` : la demande peut être envoyée à l’agent de spécification ;
+   - `ai:needs-info` : des informations obligatoires manquent ;
+   - `ai:needs-approval` : la demande vient d’un compte externe.
+
+Cette étape ne lance encore aucun modèle, ne modifie pas le code et ne déploie rien.
+
+## Sécurité
+
+Les Issues du dépôt étant publiques, l’appartenance de l’auteur est contrôlée avant de déclarer une demande prête. Ce garde-fou devra aussi être vérifié par tous les futurs workflows qui consommeront des crédits IA ou disposeront de droits d’écriture.
+
+## Test local
+
+```bash
+yarn test:pipeline
+```
+
+## Prochaine étape
+
+Un agent de spécification consommera les Issues portant le label `ai:ready-for-spec`, analysera le dépôt et proposera une spécification technique et fonctionnelle soumise à validation humaine.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --ext .js,.ts,.vue --fix",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
+    "test:pipeline": "node --test .github/scripts/*.test.mjs",
     "typecheck": "nuxt typecheck"
   },
   "devDependencies": {


### PR DESCRIPTION
## Ce qui change

- ajoute un formulaire GitHub Issue en français pour les demandes de fonctionnalités non-techniques ;
- valide et normalise automatiquement la demande en brief initial ;
- classe la demande avec les labels `ai:ready-for-spec`, `ai:needs-info` ou `ai:needs-approval` ;
- réserve le déclenchement futur des agents aux propriétaires, membres et collaborateurs du dépôt ;
- ajoute sept tests unitaires dédiés au pipeline et les exécute dans la CI ;
- documente le fonctionnement et les garde-fous de cette première étape.

## Pourquoi

Cette PR crée le point d'entrée stable du futur pipeline agentique. Un contributeur non développeur peut décrire un résultat attendu sans écrire une spécification technique, tandis que les futurs agents recevront une structure prévisible et vérifiée.

Cette étape ne lance aucun modèle, ne modifie pas le code applicatif et ne déploie rien automatiquement.

## Validation

- `yarn test:pipeline` — 7 tests réussis
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- validation syntaxique des fichiers YAML

## Test manuel après fusion

Créer une Issue avec le modèle **Fonctionnalité assistée par IA** et vérifier qu'elle reçoit le label `ai:ready-for-spec` ainsi qu'un commentaire contenant le brief normalisé.
