### PR TITLE
Fix AI feature intake trigger

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-feature.yml
+++ b/.github/ISSUE_TEMPLATE/ai-feature.yml
@@ -7,7 +7,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        <!-- synupsis-ai-request:v1 -->
         Décris le besoin avec tes mots. Tu n'as pas besoin de proposer une solution technique : les agents s'en chargeront.
 
   - type: textarea

--- a/.github/scripts/feature-request-intake.mjs
+++ b/.github/scripts/feature-request-intake.mjs
@@ -1,5 +1,6 @@
 const REQUEST_MARKER = '<!-- synupsis-ai-request:v1 -->'
 const COMMENT_MARKER = '<!-- synupsis-ai-intake:v1 -->'
+const FEATURE_TITLE_PREFIX = '[Feature IA]'
 
 const FIELD_DEFINITIONS = [
   { key: 'problem', heading: 'Problème à résoudre', required: true },
@@ -88,6 +89,18 @@ export function validateFeatureRequest(featureRequest) {
 
 export function isTrustedAssociation(association = '') {
   return TRUSTED_ASSOCIATIONS.has(association.toUpperCase())
+}
+
+export function isFeatureRequestIssue(issue = {}) {
+  const title = typeof issue.title === 'string' ? issue.title.trimStart() : ''
+  const body = typeof issue.body === 'string' ? issue.body : ''
+  const hasExpectedSections = body.includes('### Problème à résoudre')
+    && body.includes('### Résultat attendu')
+    && body.includes('### Critères de validation')
+
+  return title.startsWith(FEATURE_TITLE_PREFIX)
+    || body.includes(REQUEST_MARKER)
+    || hasExpectedSections
 }
 
 function blockquote(value) {
@@ -187,14 +200,29 @@ async function ensureLabel(github, owner, repo, label) {
 }
 
 export async function handleFeatureRequest({ github, context, core }) {
-  const issue = context.payload.issue
+  const { owner, repo } = context.repo
+  let issue = context.payload.issue
 
-  if (!issue || !issue.body?.includes(REQUEST_MARKER)) {
+  if (!issue && context.payload.inputs?.issue_number) {
+    const issueNumber = Number(context.payload.inputs.issue_number)
+
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new Error('The workflow_dispatch issue_number input must be a positive integer.')
+    }
+
+    const response = await github.rest.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    })
+    issue = response.data
+  }
+
+  if (!issue || !isFeatureRequestIssue(issue)) {
     core.info('This issue is not a Synupsis AI feature request.')
     return
   }
 
-  const { owner, repo } = context.repo
   const issueNumber = issue.number
   const featureRequest = normalizeFeatureRequest(issue.body)
   const missingFields = validateFeatureRequest(featureRequest)

--- a/.github/scripts/feature-request-intake.test.mjs
+++ b/.github/scripts/feature-request-intake.test.mjs
@@ -5,14 +5,14 @@ import {
   buildNormalizedBrief,
   buildStatusComment,
   handleFeatureRequest,
+  isFeatureRequestIssue,
   isTrustedAssociation,
   normalizeFeatureRequest,
   parseSections,
   validateFeatureRequest,
 } from './feature-request-intake.mjs'
 
-const completeBody = `<!-- synupsis-ai-request:v1 -->
-### Problème à résoudre
+const completeBody = `### Problème à résoudre
 
 Les utilisateurs perdent leur progression.
 
@@ -76,6 +76,12 @@ test('only repository owners, members and collaborators are trusted', () => {
   assert.equal(isTrustedAssociation('NONE'), false)
 })
 
+test('feature requests are detected without the discarded form markdown block', () => {
+  assert.equal(isFeatureRequestIssue({ title: '[Feature IA] Une amélioration', body: completeBody }), true)
+  assert.equal(isFeatureRequestIssue({ title: 'Titre modifié', body: completeBody }), true)
+  assert.equal(isFeatureRequestIssue({ title: 'Rapport de bug', body: 'Une erreur apparaît.' }), false)
+})
+
 test('ready comments contain the normalized brief without live mentions', () => {
   const request = normalizeFeatureRequest(completeBody.replace('Les utilisateurs', '@product Les utilisateurs'))
   const brief = buildNormalizedBrief(request)
@@ -114,6 +120,15 @@ test('handleFeatureRequest creates labels and one reusable status comment', asyn
         listComments: async () => {},
         createComment: async ({ body }) => comments.push(body),
         updateComment: async () => {},
+        get: async () => ({
+          data: {
+            number: 42,
+            title: '[Feature IA] Reprendre une story',
+            body: completeBody,
+            author_association: 'MEMBER',
+            labels: [],
+          },
+        }),
       },
     },
     paginate: async () => [],
@@ -121,12 +136,7 @@ test('handleFeatureRequest creates labels and one reusable status comment', asyn
   const context = {
     repo: { owner: 'synupsis', repo: 'synupsis-web' },
     payload: {
-      issue: {
-        number: 42,
-        body: completeBody,
-        author_association: 'MEMBER',
-        labels: [],
-      },
+      inputs: { issue_number: '42' },
     },
   }
   const core = {

--- a/.github/workflows/ai-feature-intake.yml
+++ b/.github/workflows/ai-feature-intake.yml
@@ -6,19 +6,28 @@ on:
       - opened
       - edited
       - reopened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Numéro de l’Issue à retraiter
+        required: true
+        type: string
 
 permissions:
   contents: read
   issues: write
 
 concurrency:
-  group: ai-feature-intake-${{ github.event.issue.number }}
+  group: ai-feature-intake-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 jobs:
   normalize:
     name: Validate and normalize the request
-    if: contains(github.event.issue.body, '<!-- synupsis-ai-request:v1 -->')
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.issue.title, '[Feature IA]') ||
+      contains(github.event.issue.body, '### Problème à résoudre')
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -28,6 +28,8 @@ Le formulaire demande :
 
 Cette étape ne lance encore aucun modèle, ne modifie pas le code et ne déploie rien.
 
+Un mainteneur peut aussi relancer manuellement le workflow avec le numéro d’une Issue depuis l’onglet **Actions**, par exemple après la correction d’un workflow ou d’une configuration.
+
 ## Sécurité
 
 Les Issues du dépôt étant publiques, l’appartenance de l’auteur est contrôlée avant de déclarer une demande prête. Ce garde-fou devra aussi être vérifié par tous les futurs workflows qui consommeront des crédits IA ou disposeront de droits d’écriture.


### PR DESCRIPTION
## Ce qui change

- détecte les demandes via le préfixe `[Feature IA]` et les sections réelles du formulaire ;
- ne dépend plus du bloc markdown statique, que GitHub ne conserve pas dans l’Issue créée ;
- ajoute une relance manuelle du workflow par numéro d’Issue ;
- couvre le corps réel produit par GitHub et la relance manuelle avec des tests.

## Cause

Les champs `type: markdown` d’un GitHub Issue Form sont affichés pendant la saisie mais ne sont pas recopiés dans le corps final de l’Issue. Le marqueur HTML utilisé par le workflow était donc absent et le job était ignoré.

## Impact

Après fusion, l’intake pourra être rejoué sur l’Issue #12 sans modifier ou fermer celle-ci.

## Validation

- `yarn test:pipeline` — 8 tests réussis
- `yarn lint`
- validation syntaxique des fichiers YAML
