### PR TITLE
Add human specification approval

### DIFF
--- a/.github/scripts/feature-specification-approval.mjs
+++ b/.github/scripts/feature-specification-approval.mjs
@@ -1,0 +1,151 @@
+const APPROVAL_COMMAND = '/approve-spec'
+const SPECIFICATION_COMMENT_MARKER = '<!-- synupsis-ai-spec:v1 -->'
+const APPROVAL_COMMENT_MARKER = '<!-- synupsis-ai-approval:v1 -->'
+const SPECIFICATION_READY_LABEL = 'ai:spec-ready'
+
+const APPROVED_LABEL = {
+  name: 'ai:spec-approved',
+  color: '1f883d',
+  description: 'Spécification validée par un membre du dépôt',
+}
+
+const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
+
+function isTrustedAssociation(association = '') {
+  return TRUSTED_ASSOCIATIONS.has(association.toUpperCase())
+}
+
+function labelsOf(issue) {
+  return new Set(
+    (issue.labels ?? [])
+      .map((label) => typeof label === 'string' ? label : label.name)
+      .filter(Boolean),
+  )
+}
+
+export function isSpecificationApprovalCommand(body = '') {
+  return body === APPROVAL_COMMAND
+}
+
+export function buildApprovalComment() {
+  return [
+    APPROVAL_COMMENT_MARKER,
+    '### Spécification approuvée',
+    '',
+    'La validation humaine est enregistrée. La demande est maintenant prête pour le futur agent de développement.',
+    '',
+    'Aucun code ni déploiement n’a encore été déclenché.',
+  ].join('\n')
+}
+
+async function ensureLabel(github, owner, repo, label) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: label.name })
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error
+    }
+
+    try {
+      await github.rest.issues.createLabel({ owner, repo, ...label })
+    } catch (createError) {
+      // Another simultaneous run may have created the label first.
+      if (createError.status !== 422) {
+        throw createError
+      }
+    }
+  }
+}
+
+export async function handleSpecificationApproval({ github, context, core }) {
+  const eventIssue = context.payload.issue
+  const comment = context.payload.comment
+
+  if (!eventIssue || !comment || !isSpecificationApprovalCommand(comment.body)) {
+    core.info('This comment is not a specification approval command.')
+    core.setOutput('approval_status', 'ignored')
+    return
+  }
+
+  if (eventIssue.pull_request) {
+    core.warning('Specification approval commands are not accepted on pull requests.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+
+  if (!isTrustedAssociation(comment.author_association)) {
+    core.warning('The approval command was posted by an untrusted account.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+
+  const issueNumber = Number(eventIssue.number)
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error('The approval event does not contain a valid Issue number.')
+  }
+
+  const { owner, repo } = context.repo
+  const issueResponse = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  })
+  const issue = issueResponse.data
+
+  if (!isTrustedAssociation(issue.author_association)) {
+    throw new Error(`#${issueNumber} was not created by a trusted repository member.`)
+  }
+
+  if (!labelsOf(issue).has(SPECIFICATION_READY_LABEL)) {
+    throw new Error(`#${issueNumber} is not labelled ${SPECIFICATION_READY_LABEL}.`)
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })
+  const specificationComment = comments.find((candidate) =>
+    candidate.user?.type === 'Bot'
+    && candidate.body?.includes(SPECIFICATION_COMMENT_MARKER),
+  )
+
+  if (!specificationComment) {
+    throw new Error(`#${issueNumber} does not contain a published agent specification.`)
+  }
+
+  await ensureLabel(github, owner, repo, APPROVED_LABEL)
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [APPROVED_LABEL.name],
+  })
+
+  const body = buildApprovalComment()
+  const previousApprovalComment = comments.find((candidate) =>
+    candidate.user?.type === 'Bot'
+    && candidate.body?.includes(APPROVAL_COMMENT_MARKER),
+  )
+
+  if (previousApprovalComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: previousApprovalComment.id,
+      body,
+    })
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body,
+    })
+  }
+
+  core.setOutput('approval_status', APPROVED_LABEL.name)
+  core.setOutput('issue_number', String(issueNumber))
+  core.info(`Specification for #${issueNumber} approved.`)
+}

--- a/.github/scripts/feature-specification-approval.test.mjs
+++ b/.github/scripts/feature-specification-approval.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildApprovalComment,
+  handleSpecificationApproval,
+  isSpecificationApprovalCommand,
+} from './feature-specification-approval.mjs'
+
+const readyIssue = {
+  number: 12,
+  author_association: 'MEMBER',
+  labels: [{ name: 'ai:spec-ready' }],
+}
+
+const specificationComment = {
+  id: 100,
+  user: { type: 'Bot' },
+  body: '<!-- synupsis-ai-spec:v1 -->\n### Spécification proposée',
+}
+
+function createCore() {
+  const outputs = new Map()
+  return {
+    outputs,
+    core: {
+      info: () => {},
+      warning: () => {},
+      setOutput: (name, value) => outputs.set(name, value),
+    },
+  }
+}
+
+test('only the exact approval command is accepted', () => {
+  assert.equal(isSpecificationApprovalCommand('/approve-spec'), true)
+  assert.equal(isSpecificationApprovalCommand('/approve-spec maintenant'), false)
+  assert.equal(isSpecificationApprovalCommand(' /approve-spec'), false)
+  assert.equal(isSpecificationApprovalCommand('/APPROVE-SPEC'), false)
+})
+
+test('approval comments explain that development has not started', () => {
+  const comment = buildApprovalComment()
+
+  assert.match(comment, /Spécification approuvée/)
+  assert.match(comment, /Aucun code ni déploiement/)
+})
+
+test('commands from untrusted accounts are rejected without GitHub writes', async () => {
+  let writes = 0
+  const { core, outputs } = createCore()
+  const github = {
+    rest: {
+      issues: {
+        get: async () => { writes++; return { data: readyIssue } },
+      },
+    },
+  }
+  const context = {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: readyIssue,
+      comment: { body: '/approve-spec', author_association: 'NONE' },
+    },
+  }
+
+  await handleSpecificationApproval({ github, context, core })
+
+  assert.equal(writes, 0)
+  assert.equal(outputs.get('approval_status'), 'rejected')
+})
+
+test('a trusted command requires a ready, bot-published specification', async () => {
+  const { core } = createCore()
+  const context = {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: readyIssue,
+      comment: { body: '/approve-spec', author_association: 'OWNER' },
+    },
+  }
+
+  await assert.rejects(
+    handleSpecificationApproval({
+      github: {
+        rest: {
+          issues: {
+            get: async () => ({ data: { ...readyIssue, labels: [] } }),
+          },
+        },
+      },
+      context,
+      core,
+    }),
+    /ai:spec-ready/,
+  )
+
+  await assert.rejects(
+    handleSpecificationApproval({
+      github: {
+        rest: {
+          issues: {
+            get: async () => ({ data: readyIssue }),
+            listComments: async () => {},
+          },
+        },
+        paginate: async () => [],
+      },
+      context,
+      core,
+    }),
+    /published agent specification/,
+  )
+})
+
+test('a trusted command records one reusable approval', async () => {
+  const createdLabels = []
+  const addedLabels = []
+  const updatedComments = []
+  const { core, outputs } = createCore()
+  const github = {
+    rest: {
+      issues: {
+        get: async () => ({ data: readyIssue }),
+        getLabel: async () => {
+          const error = new Error('Not found')
+          error.status = 404
+          throw error
+        },
+        createLabel: async ({ name }) => createdLabels.push(name),
+        addLabels: async ({ labels }) => addedLabels.push(...labels),
+        listComments: async () => {},
+        createComment: async () => {
+          throw new Error('The existing approval comment should be updated.')
+        },
+        updateComment: async ({ comment_id, body }) => {
+          updatedComments.push({ comment_id, body })
+        },
+      },
+    },
+    paginate: async () => [
+      specificationComment,
+      {
+        id: 101,
+        user: { type: 'Bot' },
+        body: '<!-- synupsis-ai-approval:v1 -->\nAncienne validation',
+      },
+    ],
+  }
+  const context = {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: readyIssue,
+      comment: { body: '/approve-spec', author_association: 'COLLABORATOR' },
+    },
+  }
+
+  await handleSpecificationApproval({ github, context, core })
+
+  assert.deepEqual(createdLabels, ['ai:spec-approved'])
+  assert.deepEqual(addedLabels, ['ai:spec-approved'])
+  assert.equal(updatedComments.length, 1)
+  assert.equal(updatedComments[0].comment_id, 101)
+  assert.match(updatedComments[0].body, /Spécification approuvée/)
+  assert.equal(outputs.get('approval_status'), 'ai:spec-approved')
+  assert.equal(outputs.get('issue_number'), '12')
+})

--- a/.github/scripts/feature-specification.mjs
+++ b/.github/scripts/feature-specification.mjs
@@ -165,7 +165,7 @@ export function buildSpecificationComment(result) {
     '',
     '---',
     ready
-      ? 'Cette proposition attend une validation humaine avant toute génération de code.'
+      ? 'Cette proposition attend une validation humaine avant toute génération de code. Pour l’approuver, commente `/approve-spec` dans cette Issue.'
       : 'Réponds aux questions dans l’Issue, puis relance le workflow de collecte. Aucun code n’a été généré.',
   )
 

--- a/.github/scripts/feature-specification.test.mjs
+++ b/.github/scripts/feature-specification.test.mjs
@@ -171,5 +171,6 @@ test('publishFeatureSpecification creates labels and one reusable comment', asyn
   assert.deepEqual(removedLabels, ['ai:spec-needs-info'])
   assert.equal(comments.length, 1)
   assert.match(comments[0], /Spécification proposée/)
+  assert.match(comments[0], /\/approve-spec/)
   assert.equal(outputs.get('specification-status'), 'ai:spec-ready')
 })

--- a/.github/workflows/ai-feature-approval.yml
+++ b/.github/workflows/ai-feature-approval.yml
@@ -1,0 +1,45 @@
+name: AI feature approval
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: {}
+
+concurrency:
+  group: ai-feature-approval-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    name: Record human specification approval
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/approve-spec'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      approval_status: ${{ steps.approve.outputs.approval_status }}
+      issue_number: ${{ steps.approve.outputs.issue_number }}
+
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Validate and record the approval
+        id: approve
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/feature-specification-approval.mjs`,
+            )
+            const { handleSpecificationApproval } = await import(moduleUrl.href)
+            await handleSpecificationApproval({ github, context, core })

--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -40,6 +40,23 @@ Lorsqu’une demande reçoit le statut `ai:ready-for-spec`, le workflow `AI feat
 
 La spécification couvre le comportement, les fichiers concernés, l’approche technique, l’impact Supabase/RLS, l’accessibilité, les étapes d’implémentation et les tests. Elle reste soumise à validation humaine. Aucun code ni déploiement n’est encore produit.
 
+## Étape 3 — Validation humaine
+
+Un propriétaire, membre ou collaborateur du dépôt approuve la proposition en ajoutant exactement ce commentaire dans l’Issue :
+
+```text
+/approve-spec
+```
+
+Le workflow `AI feature approval` contrôle que :
+
+- la commande vient d’un compte autorisé ;
+- la cible est bien une Issue et non une Pull Request ;
+- le label `ai:spec-ready` est encore présent ;
+- une spécification a réellement été publiée par le bot.
+
+Après validation, il ajoute `ai:spec-approved` et publie une confirmation. Cette étape ne génère encore aucun code : le label constituera le déclencheur sécurisé du futur agent de développement.
+
 Un mainteneur peut aussi relancer manuellement le workflow avec le numéro d’une Issue depuis l’onglet **Actions**, par exemple après la correction d’un workflow ou d’une configuration.
 
 ## Sécurité
@@ -54,7 +71,7 @@ yarn test:pipeline
 
 ## Relance manuelle
 
-Les deux workflows acceptent un numéro d’Issue depuis l’onglet **Actions**. Relancer `AI feature intake` rejoue toute la chaîne si la demande est complète. Relancer directement `AI feature specification` ne rejoue que l’analyse.
+Les workflows de collecte et de spécification acceptent un numéro d’Issue depuis l’onglet **Actions**. Relancer `AI feature intake` rejoue toute la chaîne si la demande est complète. Relancer directement `AI feature specification` ne rejoue que l’analyse. L’approbation, elle, exige volontairement la commande publique `/approve-spec` afin de conserver une trace humaine explicite dans l’Issue.
 
 ## Prochaine étape
 


### PR DESCRIPTION
## Ce qui change

- ajoute la commande humaine `/approve-spec` sur les Issues ;
- vérifie l’auteur de la commande, l’Issue, son label et la présence d’une spécification publiée par le bot ;
- ajoute le label `ai:spec-approved` et un commentaire de confirmation idempotent ;
- expose le statut et le numéro d’Issue pour le futur agent de développement ;
- documente cette nouvelle étape du pipeline.

## Sécurité et impact

- les comptes externes sont refusés avant toute écriture GitHub ;
- la commande n’est jamais acceptée sur une Pull Request ;
- aucune clé OpenAI n’est utilisée ;
- aucun code ni déploiement n’est déclenché à cette étape.

## Validation

- `yarn test:pipeline` — 19 tests
- `yarn lint`
- `yarn typecheck`
- validation syntaxique des workflows YAML

Après fusion, l’Issue #12 sera approuvée avec la commande réelle pour tester le workflow.
