### PR TITLE
feat: add AI preview acceptance gate

### DIFF
--- a/.github/scripts/feature-preview-acceptance.mjs
+++ b/.github/scripts/feature-preview-acceptance.mjs
@@ -1,0 +1,444 @@
+import { sanitizeProductText } from './feature-development.mjs'
+import {
+  issueNumberFromReviewBranch,
+  reviewHeadMarker,
+  reviewVerdictMarker,
+} from './feature-review.mjs'
+
+const PREVIEW_APPROVAL_COMMAND = '/approve-preview'
+const REVIEW_COMMENT_MARKER = '<!-- synupsis-ai-review:v1 -->'
+const PREVIEW_APPROVAL_MARKER = '<!-- synupsis-ai-preview-approval:v1 -->'
+const INTEGRATION_COMMENT_MARKER = '<!-- synupsis-ai-integrated-dev:v1 -->'
+const APPROVED_LABEL = 'ai:spec-approved'
+const IMPLEMENTATION_LABEL = 'ai:implementation-pr'
+const REVIEW_PASSED_LABEL = 'ai:review-passed'
+const REVIEW_CHANGES_LABEL = 'ai:review-changes'
+const REVIEW_BLOCKED_LABEL = 'ai:review-blocked'
+const CORRECTION_IN_PROGRESS_LABEL = 'ai:fix-in-progress'
+const CORRECTION_BLOCKED_LABEL = 'ai:fix-blocked'
+const NETLIFY_STATUS_CONTEXT = 'netlify/dev-synupsis/deploy-preview'
+const CI_CHECK_NAME = 'Lint, typecheck and build'
+const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
+
+const ACCEPTANCE_LABELS = {
+  approved: {
+    name: 'ai:preview-approved',
+    color: '1f883d',
+    description: 'La Deploy Preview a été validée par un membre du dépôt',
+  },
+  integrated: {
+    name: 'ai:integrated-dev',
+    color: '8250df',
+    description: 'La fonctionnalité validée est intégrée à l’environnement de développement',
+  },
+}
+
+function normalizePositiveInteger(value, name) {
+  const normalized = Number(value)
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throw new Error(`The ${name} input must be a positive integer.`)
+  }
+  return normalized
+}
+
+function validateHeadSha(value, name = 'head SHA') {
+  if (typeof value !== 'string' || !/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error(`The ${name} is invalid.`)
+  }
+  return value.toLowerCase()
+}
+
+function labelsOf(item) {
+  return new Set(
+    (item.labels ?? [])
+      .map((label) => typeof label === 'string' ? label : label.name)
+      .filter(Boolean),
+  )
+}
+
+function isTrustedAssociation(association = '') {
+  return TRUSTED_ASSOCIATIONS.has(association.toUpperCase())
+}
+
+function neutralizeMentions(value) {
+  return value.replaceAll('@', '@\u200b')
+}
+
+export function isPreviewApprovalCommand(body = '') {
+  return body === PREVIEW_APPROVAL_COMMAND
+}
+
+export function previewApprovalHeadMarker(headSha) {
+  return `<!-- synupsis-ai-preview-approval-head:${validateHeadSha(headSha)} -->`
+}
+
+function assertAcceptablePullRequest({ pullRequest, context }) {
+  const expectedRepository = `${context.repo.owner}/${context.repo.repo}`
+  if (pullRequest.state !== 'open') {
+    throw new Error(`Pull Request #${pullRequest.number} is not open.`)
+  }
+  if (pullRequest.base?.ref !== 'develop') {
+    throw new Error(`Pull Request #${pullRequest.number} does not target develop.`)
+  }
+  if (pullRequest.head?.repo?.full_name !== expectedRepository) {
+    throw new Error(`Pull Request #${pullRequest.number} does not come from the trusted repository.`)
+  }
+  return issueNumberFromReviewBranch(pullRequest.head?.ref)
+}
+
+function assertAcceptedLabels({ pullRequest, issue, issueNumber }) {
+  const pullRequestLabels = labelsOf(pullRequest)
+  const issueLabels = labelsOf(issue)
+  if (!isTrustedAssociation(issue.author_association)) {
+    throw new Error(`#${issueNumber} was not created by a trusted repository member.`)
+  }
+  for (const requiredLabel of [APPROVED_LABEL, IMPLEMENTATION_LABEL, REVIEW_PASSED_LABEL]) {
+    if (!issueLabels.has(requiredLabel)) {
+      throw new Error(`#${issueNumber} is missing required label ${requiredLabel}.`)
+    }
+  }
+  if (!pullRequestLabels.has(REVIEW_PASSED_LABEL)) {
+    throw new Error(`Pull Request #${pullRequest.number} is not labelled ${REVIEW_PASSED_LABEL}.`)
+  }
+  const forbiddenLabels = [
+    REVIEW_CHANGES_LABEL,
+    REVIEW_BLOCKED_LABEL,
+    CORRECTION_IN_PROGRESS_LABEL,
+    CORRECTION_BLOCKED_LABEL,
+  ]
+  for (const forbiddenLabel of forbiddenLabels) {
+    if (pullRequestLabels.has(forbiddenLabel) || issueLabels.has(forbiddenLabel)) {
+      throw new Error(`The preview cannot be accepted while ${forbiddenLabel} is present.`)
+    }
+  }
+  return { pullRequestLabels, issueLabels }
+}
+
+function latestByDate(items, dateFields) {
+  return [...items].sort((left, right) => {
+    const leftDate = dateFields.map((field) => Date.parse(left[field] ?? '')).find(Number.isFinite) ?? 0
+    const rightDate = dateFields.map((field) => Date.parse(right[field] ?? '')).find(Number.isFinite) ?? 0
+    return rightDate - leftDate
+  })[0]
+}
+
+function validateNetlifyPreviewUrl(value, pullRequestNumber) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('The successful Netlify status does not contain a valid preview URL.')
+  }
+  const expectedHost = `deploy-preview-${pullRequestNumber}--dev-synupsis.netlify.app`
+  if (url.protocol !== 'https:' || url.hostname !== expectedHost) {
+    throw new Error(`Unexpected Netlify preview URL ${url.href}.`)
+  }
+  return url.href
+}
+
+export async function verifyPreviewChecks({ github, owner, repo, pullRequest }) {
+  const checksResponse = await github.rest.checks.listForRef({
+    owner,
+    repo,
+    ref: pullRequest.head.sha,
+    per_page: 100,
+  })
+  const ciCheck = latestByDate(
+    checksResponse.data.check_runs.filter((checkRun) =>
+      checkRun.name === CI_CHECK_NAME && checkRun.app?.slug === 'github-actions',
+    ),
+    ['completed_at', 'started_at'],
+  )
+  if (!ciCheck || ciCheck.status !== 'completed' || ciCheck.conclusion !== 'success') {
+    throw new Error(`Pull Request #${pullRequest.number} does not have a successful current CI check.`)
+  }
+
+  const statusResponse = await github.rest.repos.getCombinedStatusForRef({
+    owner,
+    repo,
+    ref: pullRequest.head.sha,
+    per_page: 100,
+  })
+  const netlifyStatus = latestByDate(
+    statusResponse.data.statuses.filter((status) => status.context === NETLIFY_STATUS_CONTEXT),
+    ['updated_at', 'created_at'],
+  )
+  if (!netlifyStatus || netlifyStatus.state !== 'success') {
+    throw new Error(`Pull Request #${pullRequest.number} does not have a successful Netlify Deploy Preview.`)
+  }
+
+  return {
+    ciUrl: ciCheck.details_url,
+    previewUrl: validateNetlifyPreviewUrl(netlifyStatus.target_url, pullRequest.number),
+  }
+}
+
+function findCurrentApprovedReview(comments, pullRequest) {
+  const currentReview = comments.find((comment) =>
+    comment.user?.type === 'Bot'
+    && comment.body?.includes(REVIEW_COMMENT_MARKER)
+    && comment.body?.includes(reviewHeadMarker(pullRequest.head.sha))
+    && comment.body?.includes(reviewVerdictMarker('approved')),
+  )
+  if (!currentReview) {
+    throw new Error(`Pull Request #${pullRequest.number} has no approved review tied to its current head SHA.`)
+  }
+  return currentReview
+}
+
+async function ensureLabel(github, owner, repo, label) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: label.name })
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error
+    }
+    try {
+      await github.rest.issues.createLabel({ owner, repo, ...label })
+    } catch (createError) {
+      if (createError.status !== 422) {
+        throw createError
+      }
+    }
+  }
+}
+
+async function getAcceptanceContext({
+  github,
+  context,
+  pullRequestNumber,
+  expectedHeadSha,
+  requireApprovalComment = false,
+}) {
+  const normalizedPullRequestNumber = normalizePositiveInteger(
+    pullRequestNumber,
+    'pull_request_number',
+  )
+  const { owner, repo } = context.repo
+  const pullRequestResponse = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: normalizedPullRequestNumber,
+  })
+  const pullRequest = pullRequestResponse.data
+  const issueNumber = assertAcceptablePullRequest({ pullRequest, context })
+  if (
+    expectedHeadSha
+    && pullRequest.head.sha.toLowerCase() !== validateHeadSha(expectedHeadSha, 'expected head SHA')
+  ) {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} changed during preview acceptance.`)
+  }
+
+  const issueResponse = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  })
+  const issue = issueResponse.data
+  const { pullRequestLabels, issueLabels } = assertAcceptedLabels({
+    pullRequest,
+    issue,
+    issueNumber,
+  })
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: normalizedPullRequestNumber,
+    per_page: 100,
+  })
+  findCurrentApprovedReview(comments, pullRequest)
+  const approvalHeadMarker = previewApprovalHeadMarker(pullRequest.head.sha)
+  const approvalComment = comments.find((comment) =>
+    comment.user?.type === 'Bot'
+    && comment.body?.includes(PREVIEW_APPROVAL_MARKER)
+    && comment.body?.includes(approvalHeadMarker),
+  )
+  if (requireApprovalComment && !approvalComment) {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} has no preview approval for this SHA.`)
+  }
+
+  const checks = await verifyPreviewChecks({ github, owner, repo, pullRequest })
+  return {
+    owner,
+    repo,
+    pullRequestNumber: normalizedPullRequestNumber,
+    pullRequest,
+    pullRequestLabels,
+    issueNumber,
+    issue,
+    issueLabels,
+    approvalComment,
+    ...checks,
+  }
+}
+
+export function buildPreviewApprovalComment({ headSha, previewUrl }) {
+  return [
+    PREVIEW_APPROVAL_MARKER,
+    previewApprovalHeadMarker(headSha),
+    '### Deploy Preview approuvée',
+    '',
+    `La validation humaine de la [preview Netlify](${previewUrl}) est enregistrée pour le commit \`${headSha.slice(0, 12)}\`.`,
+    '',
+    'La Pull Request va être fusionnée par squash dans `develop`, puis la CI et le déploiement de l’environnement de développement seront relancés.',
+    '',
+    'Cette commande ne déploie pas en production.',
+  ].join('\n')
+}
+
+export async function handlePreviewApproval({ github, context, core }) {
+  const eventIssue = context.payload.issue
+  const comment = context.payload.comment
+  if (!eventIssue || !comment || !isPreviewApprovalCommand(comment.body)) {
+    core.info('This comment is not a preview approval command.')
+    core.setOutput('approval_status', 'ignored')
+    return
+  }
+  if (!eventIssue.pull_request) {
+    core.warning('Preview approval commands are accepted only on pull requests.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+  if (!isTrustedAssociation(comment.author_association)) {
+    core.warning('The preview approval command was posted by an untrusted account.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+
+  const acceptance = await getAcceptanceContext({
+    github,
+    context,
+    pullRequestNumber: eventIssue.number,
+  })
+  await ensureLabel(github, acceptance.owner, acceptance.repo, ACCEPTANCE_LABELS.approved)
+  if (!acceptance.pullRequestLabels.has(ACCEPTANCE_LABELS.approved.name)) {
+    await github.rest.issues.addLabels({
+      owner: acceptance.owner,
+      repo: acceptance.repo,
+      issue_number: acceptance.pullRequestNumber,
+      labels: [ACCEPTANCE_LABELS.approved.name],
+    })
+  }
+  if (!acceptance.issueLabels.has(ACCEPTANCE_LABELS.approved.name)) {
+    await github.rest.issues.addLabels({
+      owner: acceptance.owner,
+      repo: acceptance.repo,
+      issue_number: acceptance.issueNumber,
+      labels: [ACCEPTANCE_LABELS.approved.name],
+    })
+  }
+  if (!acceptance.approvalComment) {
+    await github.rest.issues.createComment({
+      owner: acceptance.owner,
+      repo: acceptance.repo,
+      issue_number: acceptance.pullRequestNumber,
+      body: buildPreviewApprovalComment({
+        headSha: acceptance.pullRequest.head.sha,
+        previewUrl: acceptance.previewUrl,
+      }),
+    })
+  }
+
+  core.setOutput('approval_status', ACCEPTANCE_LABELS.approved.name)
+  core.setOutput('pull_request_number', String(acceptance.pullRequestNumber))
+  core.setOutput('issue_number', String(acceptance.issueNumber))
+  core.setOutput('head_sha', acceptance.pullRequest.head.sha)
+  core.setOutput('preview_url', acceptance.previewUrl)
+}
+
+export async function mergeAcceptedPreview({
+  github,
+  context,
+  core,
+  pullRequestNumber,
+  expectedHeadSha,
+}) {
+  const acceptance = await getAcceptanceContext({
+    github,
+    context,
+    pullRequestNumber,
+    expectedHeadSha,
+    requireApprovalComment: true,
+  })
+
+  if (acceptance.pullRequest.draft) {
+    await github.graphql(
+      `mutation MarkPullRequestReady($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { isDraft }
+        }
+      }`,
+      { pullRequestId: acceptance.pullRequest.node_id },
+    )
+  }
+
+  const cleanTitle = sanitizeProductText(acceptance.pullRequest.title, 200)
+  const mergeResponse = await github.rest.pulls.merge({
+    owner: acceptance.owner,
+    repo: acceptance.repo,
+    pull_number: acceptance.pullRequestNumber,
+    sha: acceptance.pullRequest.head.sha,
+    merge_method: 'squash',
+    commit_title: `${cleanTitle} (#${acceptance.pullRequestNumber})`,
+    commit_message: `Preview validée pour l’Issue #${acceptance.issueNumber}.`,
+  })
+  if (!mergeResponse.data.merged || !mergeResponse.data.sha) {
+    throw new Error(
+      `GitHub refused to merge Pull Request #${acceptance.pullRequestNumber}: ${mergeResponse.data.message ?? 'unknown reason'}.`,
+    )
+  }
+
+  await ensureLabel(github, acceptance.owner, acceptance.repo, ACCEPTANCE_LABELS.integrated)
+  await github.rest.issues.addLabels({
+    owner: acceptance.owner,
+    repo: acceptance.repo,
+    issue_number: acceptance.issueNumber,
+    labels: [ACCEPTANCE_LABELS.integrated.name],
+  })
+  const integrationBody = [
+    INTEGRATION_COMMENT_MARKER,
+    '### Fonctionnalité intégrée en développement',
+    '',
+    `La Pull Request [#${acceptance.pullRequestNumber}](${acceptance.pullRequest.html_url}) a été fusionnée dans \`develop\` après validation de sa preview.`,
+    '',
+    `Commit d’intégration : \`${mergeResponse.data.sha.slice(0, 12)}\`.`,
+    '',
+    'Cette étape met à jour l’environnement de développement partagé. Elle ne constitue pas une mise en production.',
+  ].join('\n')
+  await github.rest.issues.createComment({
+    owner: acceptance.owner,
+    repo: acceptance.repo,
+    issue_number: acceptance.issueNumber,
+    body: integrationBody,
+  })
+  await github.rest.issues.update({
+    owner: acceptance.owner,
+    repo: acceptance.repo,
+    issue_number: acceptance.issueNumber,
+    state: 'closed',
+    state_reason: 'completed',
+  })
+
+  try {
+    await github.rest.git.deleteRef({
+      owner: acceptance.owner,
+      repo: acceptance.repo,
+      ref: `heads/${acceptance.pullRequest.head.ref}`,
+    })
+  } catch (error) {
+    if (![404, 422].includes(error.status)) {
+      throw error
+    }
+  }
+
+  await github.rest.actions.createWorkflowDispatch({
+    owner: acceptance.owner,
+    repo: acceptance.repo,
+    workflow_id: 'ci.yml',
+    ref: 'develop',
+  })
+
+  core.setOutput('integration_status', ACCEPTANCE_LABELS.integrated.name)
+  core.setOutput('merge_sha', mergeResponse.data.sha)
+  core.info(`Pull Request #${acceptance.pullRequestNumber} merged into develop.`)
+}

--- a/.github/scripts/feature-preview-acceptance.test.mjs
+++ b/.github/scripts/feature-preview-acceptance.test.mjs
@@ -1,0 +1,314 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildPreviewApprovalComment,
+  handlePreviewApproval,
+  isPreviewApprovalCommand,
+  mergeAcceptedPreview,
+  previewApprovalHeadMarker,
+  verifyPreviewChecks,
+} from './feature-preview-acceptance.mjs'
+import {
+  reviewHeadMarker,
+  reviewVerdictMarker,
+} from './feature-review.mjs'
+
+const headSha = 'a'.repeat(40)
+const mergeSha = 'c'.repeat(40)
+const previewUrl = 'https://deploy-preview-17--dev-synupsis.netlify.app/'
+
+const pullRequest = {
+  number: 17,
+  node_id: 'PR_kwDOExample',
+  state: 'open',
+  draft: true,
+  title: 'AI #12: Ajouter une barre de progression',
+  html_url: 'https://github.com/synupsis/synupsis-web/pull/17',
+  labels: [{ name: 'ai:review-passed' }],
+  head: {
+    ref: 'codex/issue-12',
+    sha: headSha,
+    repo: { full_name: 'synupsis/synupsis-web' },
+  },
+  base: { ref: 'develop' },
+}
+
+const issue = {
+  number: 12,
+  author_association: 'MEMBER',
+  labels: [
+    { name: 'ai:spec-approved' },
+    { name: 'ai:implementation-pr' },
+    { name: 'ai:review-passed' },
+  ],
+}
+
+const approvedReviewComment = {
+  user: { type: 'Bot' },
+  created_at: '2026-07-20T10:00:00Z',
+  body: [
+    '<!-- synupsis-ai-review:v1 -->',
+    reviewHeadMarker(headSha),
+    reviewVerdictMarker('approved'),
+    'Review approuvée.',
+  ].join('\n'),
+}
+
+const previewApprovalComment = {
+  user: { type: 'Bot' },
+  created_at: '2026-07-20T10:05:00Z',
+  body: [
+    '<!-- synupsis-ai-preview-approval:v1 -->',
+    previewApprovalHeadMarker(headSha),
+    'Preview approuvée.',
+  ].join('\n'),
+}
+
+function successfulCheckRuns() {
+  return [{
+    name: 'Lint, typecheck and build',
+    status: 'completed',
+    conclusion: 'success',
+    details_url: 'https://github.com/synupsis/synupsis-web/actions/runs/1',
+    completed_at: '2026-07-20T10:00:00Z',
+    app: { slug: 'github-actions' },
+  }]
+}
+
+function successfulStatuses(targetUrl = previewUrl) {
+  return [{
+    context: 'netlify/dev-synupsis/deploy-preview',
+    state: 'success',
+    target_url: targetUrl,
+    updated_at: '2026-07-20T10:01:00Z',
+  }]
+}
+
+function acceptanceGithub({
+  currentPullRequest = pullRequest,
+  currentIssue = issue,
+  comments = [approvedReviewComment],
+  checkRuns = successfulCheckRuns(),
+  statuses = successfulStatuses(),
+} = {}) {
+  const calls = {
+    addedLabels: [],
+    comments: [],
+    dispatches: [],
+    deletedRefs: [],
+    graphql: [],
+    merges: [],
+    updates: [],
+  }
+  const github = {
+    rest: {
+      actions: {
+        createWorkflowDispatch: async (input) => calls.dispatches.push(input),
+      },
+      checks: {
+        listForRef: async () => ({ data: { check_runs: checkRuns } }),
+      },
+      git: {
+        deleteRef: async (input) => calls.deletedRefs.push(input),
+      },
+      issues: {
+        addLabels: async (input) => calls.addedLabels.push(input),
+        createComment: async (input) => calls.comments.push(input),
+        createLabel: async () => {},
+        get: async ({ issue_number: issueNumber }) => {
+          assert.equal(issueNumber, 12)
+          return { data: currentIssue }
+        },
+        getLabel: async () => ({ data: {} }),
+        listComments: async () => {},
+        update: async (input) => calls.updates.push(input),
+      },
+      pulls: {
+        get: async () => ({ data: currentPullRequest }),
+        merge: async (input) => {
+          calls.merges.push(input)
+          return { data: { merged: true, sha: mergeSha } }
+        },
+      },
+      repos: {
+        getCombinedStatusForRef: async () => ({ data: { statuses } }),
+      },
+    },
+    graphql: async (...input) => calls.graphql.push(input),
+    paginate: async () => comments,
+  }
+  return { calls, github }
+}
+
+function coreRecorder() {
+  const outputs = new Map()
+  return {
+    outputs,
+    core: {
+      info: () => {},
+      warning: () => {},
+      setOutput: (name, value) => outputs.set(name, value),
+    },
+  }
+}
+
+function issueCommentContext({ association = 'MEMBER', body = '/approve-preview' } = {}) {
+  return {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: { number: 17, pull_request: {} },
+      comment: { body, author_association: association },
+    },
+  }
+}
+
+test('preview acceptance requires the exact public command', () => {
+  assert.equal(isPreviewApprovalCommand('/approve-preview'), true)
+  assert.equal(isPreviewApprovalCommand('/approve-preview '), false)
+  assert.equal(isPreviewApprovalCommand('please /approve-preview'), false)
+})
+
+test('preview verification requires current successful CI and the exact Netlify preview', async () => {
+  const { github } = acceptanceGithub()
+  const checks = await verifyPreviewChecks({
+    github,
+    owner: 'synupsis',
+    repo: 'synupsis-web',
+    pullRequest,
+  })
+  assert.equal(checks.previewUrl, previewUrl)
+
+  const failingCi = acceptanceGithub({
+    checkRuns: successfulCheckRuns().map((checkRun) => ({
+      ...checkRun,
+      conclusion: 'failure',
+    })),
+  })
+  await assert.rejects(
+    verifyPreviewChecks({
+      github: failingCi.github,
+      owner: 'synupsis',
+      repo: 'synupsis-web',
+      pullRequest,
+    }),
+    /successful current CI check/,
+  )
+
+  const wrongPreview = acceptanceGithub({
+    statuses: successfulStatuses('https://deploy-preview-18--dev-synupsis.netlify.app/'),
+  })
+  await assert.rejects(
+    verifyPreviewChecks({
+      github: wrongPreview.github,
+      owner: 'synupsis',
+      repo: 'synupsis-web',
+      pullRequest,
+    }),
+    /Unexpected Netlify preview URL/,
+  )
+})
+
+test('untrusted preview approvals are rejected before repository writes', async () => {
+  const { calls, github } = acceptanceGithub()
+  const { core, outputs } = coreRecorder()
+  await handlePreviewApproval({
+    github,
+    context: issueCommentContext({ association: 'NONE' }),
+    core,
+  })
+
+  assert.equal(outputs.get('approval_status'), 'rejected')
+  assert.equal(calls.addedLabels.length, 0)
+  assert.equal(calls.comments.length, 0)
+})
+
+test('a valid preview approval is tied to the current SHA and recorded on PR and Issue', async () => {
+  const { calls, github } = acceptanceGithub()
+  const { core, outputs } = coreRecorder()
+  await handlePreviewApproval({
+    github,
+    context: issueCommentContext(),
+    core,
+  })
+
+  assert.equal(outputs.get('approval_status'), 'ai:preview-approved')
+  assert.equal(outputs.get('pull_request_number'), '17')
+  assert.equal(outputs.get('issue_number'), '12')
+  assert.equal(outputs.get('head_sha'), headSha)
+  assert.equal(outputs.get('preview_url'), previewUrl)
+  assert.deepEqual(calls.addedLabels.map((call) => call.issue_number), [17, 12])
+  assert.equal(calls.comments.length, 1)
+  assert.match(calls.comments[0].body, new RegExp(previewApprovalHeadMarker(headSha)))
+  assert.match(calls.comments[0].body, /ne déploie pas en production/)
+})
+
+test('preview approval refuses a stale or non-approved AI review', async () => {
+  const staleReview = {
+    ...approvedReviewComment,
+    body: approvedReviewComment.body.replace(headSha, 'b'.repeat(40)),
+  }
+  const { github } = acceptanceGithub({ comments: [staleReview] })
+  const { core } = coreRecorder()
+
+  await assert.rejects(
+    handlePreviewApproval({ github, context: issueCommentContext(), core }),
+    /no approved review tied to its current head SHA/,
+  )
+})
+
+test('accepted previews are squash-merged into develop and explicitly restart CI', async () => {
+  const { calls, github } = acceptanceGithub({
+    comments: [approvedReviewComment, previewApprovalComment],
+  })
+  const { core, outputs } = coreRecorder()
+  await mergeAcceptedPreview({
+    github,
+    context: { repo: { owner: 'synupsis', repo: 'synupsis-web' } },
+    core,
+    pullRequestNumber: 17,
+    expectedHeadSha: headSha,
+  })
+
+  assert.equal(calls.graphql.length, 1)
+  assert.equal(calls.merges.length, 1)
+  assert.equal(calls.merges[0].sha, headSha)
+  assert.equal(calls.merges[0].merge_method, 'squash')
+  assert.match(calls.merges[0].commit_title, /\(#17\)$/)
+  assert.deepEqual(calls.deletedRefs.map((call) => call.ref), ['heads/codex/issue-12'])
+  assert.deepEqual(calls.dispatches, [{
+    owner: 'synupsis',
+    repo: 'synupsis-web',
+    workflow_id: 'ci.yml',
+    ref: 'develop',
+  }])
+  assert.equal(calls.updates[0].state, 'closed')
+  assert.equal(calls.updates[0].state_reason, 'completed')
+  assert.match(calls.comments.at(-1).body, /ne constitue pas une mise en production/)
+  assert.equal(outputs.get('integration_status'), 'ai:integrated-dev')
+  assert.equal(outputs.get('merge_sha'), mergeSha)
+})
+
+test('the merge revalidates that the implementation head did not change', async () => {
+  const { github } = acceptanceGithub({
+    comments: [approvedReviewComment, previewApprovalComment],
+  })
+  const { core } = coreRecorder()
+
+  await assert.rejects(
+    mergeAcceptedPreview({
+      github,
+      context: { repo: { owner: 'synupsis', repo: 'synupsis-web' } },
+      core,
+      pullRequestNumber: 17,
+      expectedHeadSha: 'b'.repeat(40),
+    }),
+    /changed during preview acceptance/,
+  )
+})
+
+test('preview approval comments make the development-only boundary explicit', () => {
+  const comment = buildPreviewApprovalComment({ headSha, previewUrl })
+  assert.match(comment, /fusionnée par squash dans `develop`/)
+  assert.match(comment, /ne déploie pas en production/)
+})

--- a/.github/scripts/feature-review.mjs
+++ b/.github/scripts/feature-review.mjs
@@ -7,6 +7,7 @@ import {
 
 const REVIEW_COMMENT_MARKER = '<!-- synupsis-ai-review:v1 -->'
 const REVIEW_HEAD_MARKER_PREFIX = 'synupsis-ai-review-head:'
+const REVIEW_VERDICT_MARKER_PREFIX = 'synupsis-ai-review-verdict:'
 const SPECIFICATION_COMMENT_MARKER = '<!-- synupsis-ai-spec:v1 -->'
 const APPROVAL_COMMENT_MARKER = '<!-- synupsis-ai-approval:v1 -->'
 const APPROVED_LABEL = 'ai:spec-approved'
@@ -75,6 +76,13 @@ export function reviewHeadMarker(headSha) {
     throw new Error('The review head SHA is invalid.')
   }
   return `<!-- ${REVIEW_HEAD_MARKER_PREFIX}${headSha.toLowerCase()} -->`
+}
+
+export function reviewVerdictMarker(verdict) {
+  if (!REVIEW_VERDICTS.has(verdict)) {
+    throw new Error('The review verdict marker is invalid.')
+  }
+  return `<!-- ${REVIEW_VERDICT_MARKER_PREFIX}${verdict} -->`
 }
 
 export function buildReviewPrompt({
@@ -348,6 +356,7 @@ export function buildReviewComment(result, headSha) {
   const parts = [
     REVIEW_COMMENT_MARKER,
     reviewHeadMarker(headSha),
+    reviewVerdictMarker(result.verdict),
     headings[result.verdict],
     '',
     neutralizeMentions(result.summary),
@@ -400,6 +409,15 @@ export function buildReviewComment(result, headSha) {
       '#### Validation humaine requise',
       '',
       'Après lecture des problèmes ci-dessus, commente exactement `/apply-review-fixes` sur cette Pull Request pour autoriser un agent séparé à proposer les corrections.',
+    )
+  }
+
+  if (result.verdict === 'approved') {
+    parts.push(
+      '',
+      '#### Acceptation de la preview',
+      '',
+      'Après avoir testé la Deploy Preview Netlify et validé le résultat fonctionnel, commente exactement `/approve-preview` sur cette Pull Request pour autoriser sa fusion dans `develop`.',
     )
   }
 

--- a/.github/scripts/feature-review.test.mjs
+++ b/.github/scripts/feature-review.test.mjs
@@ -9,6 +9,7 @@ import {
   prepareFeatureReview,
   publishFeatureReview,
   reviewHeadMarker,
+  reviewVerdictMarker,
   sanitizeReviewText,
 } from './feature-review.mjs'
 
@@ -206,10 +207,26 @@ test('review comments render findings and prevent live mentions', () => {
   assert.match(comment, /Corrections demandées/)
   assert.match(comment, /\/apply-review-fixes/)
   assert.match(comment, new RegExp(reviewHeadMarker(headSha).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  assert.match(comment, new RegExp(reviewVerdictMarker('changes_requested')))
   assert.match(comment, /pages\/recap\/\[id\]\.vue:42/)
   assert.equal(comment.includes('@product'), false)
   assert.equal(comment.includes('@\u200bproduct'), true)
   assert.match(comment, new RegExp(headSha.slice(0, 12)))
+})
+
+test('approved reviews expose the preview acceptance command', () => {
+  const comment = buildReviewComment({
+    verdict: 'approved',
+    summary: 'La proposition est prête à être testée.',
+    findings: [],
+    strengths: [],
+    verificationSteps: ['Tester sur mobile.'],
+    blockers: [],
+  }, headSha)
+
+  assert.match(comment, /\/approve-preview/)
+  assert.match(comment, /fusion dans `develop`/)
+  assert.match(comment, new RegExp(reviewVerdictMarker('approved')))
 })
 
 test('publishing revalidates the SHA and updates reusable labels and comment', async () => {

--- a/.github/scripts/feature-specification.mjs
+++ b/.github/scripts/feature-specification.mjs
@@ -13,6 +13,8 @@ const DOWNSTREAM_LABELS = [
   'ai:review-blocked',
   'ai:fix-in-progress',
   'ai:fix-blocked',
+  'ai:preview-approved',
+  'ai:integrated-dev',
 ]
 
 const LABELS = {

--- a/.github/workflows/ai-feature-preview-acceptance.yml
+++ b/.github/workflows/ai-feature-preview-acceptance.yml
@@ -1,0 +1,93 @@
+name: AI feature preview acceptance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: {}
+
+concurrency:
+  group: ai-feature-preview-acceptance-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Validate and record the human preview approval
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/approve-preview'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: read
+    outputs:
+      approval_status: ${{ steps.authorize.outputs.approval_status }}
+      pull_request_number: ${{ steps.authorize.outputs.pull_request_number }}
+      issue_number: ${{ steps.authorize.outputs.issue_number }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
+      preview_url: ${{ steps.authorize.outputs.preview_url }}
+
+    steps:
+      - name: Checkout trusted pipeline code from develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Revalidate and record preview approval
+        id: authorize
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/feature-preview-acceptance.mjs`,
+            )
+            const { handlePreviewApproval } = await import(moduleUrl.href)
+            await handlePreviewApproval({ github, context, core })
+
+  merge:
+    name: Merge the accepted preview into develop
+    needs: authorize
+    if: needs.authorize.outputs.approval_status == 'ai:preview-approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      checks: read
+      contents: write
+      issues: write
+      pull-requests: write
+      statuses: read
+
+    steps:
+      - name: Checkout trusted pipeline code from develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Revalidate and integrate the approved preview
+        uses: actions/github-script@v9
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.authorize.outputs.pull_request_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/feature-preview-acceptance.mjs`,
+            )
+            const { mergeAcceptedPreview } = await import(moduleUrl.href)
+            await mergeAcceptedPreview({
+              github,
+              context,
+              core,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
+            })

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ Run Edge Functions locally
 
 The `develop` branch is automatically deployed to the shared development environment on Netlify. Pull requests get an isolated Netlify Deploy Preview.
 
+After testing a generated Pull Request's Deploy Preview, an authorized repository member can approve it with `/approve-preview`. The pipeline then squash-merges it into `develop` only. No automatic production deployment is configured yet.
+
 ## AI feature pipeline
 
-Non-technical contributors can submit a structured feature request from the **Fonctionnalité assistée par IA** GitHub Issue form. The current intake validates and normalizes the request before it is sent to an agent.
+Non-technical contributors can submit a structured feature request from the **Fonctionnalité assistée par IA** GitHub Issue form. The pipeline specifies, implements, validates and reviews the change before presenting its Netlify preview for explicit human approval.
 
 See [the AI pipeline documentation](docs/ai-pipeline.md) for its current status and safety rules.
 

--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -1,93 +1,131 @@
 # Pipeline IA Synupsis
 
-Le pipeline doit permettre à un membre non développeur de proposer une fonctionnalité, d’obtenir une preview testable, puis de demander sa mise en production sans manipuler le code.
+Le pipeline permet à un membre non développeur de proposer une fonctionnalité, de faire produire et reviewer son implémentation, puis de tester une Deploy Preview avant son intégration dans l’environnement de développement partagé.
+
+La production n’est pas encore configurée. Aucune commande décrite ici ne déploie sur `main` ou en production.
+
+## Vue d’ensemble
+
+1. créer une Issue avec le formulaire **Fonctionnalité assistée par IA** ;
+2. laisser l’agent produire une spécification ;
+3. approuver cette spécification avec `/approve-spec` ;
+4. laisser l’agent développeur créer une Pull Request brouillon ;
+5. laisser la CI, Netlify et l’agent reviewer analyser la proposition ;
+6. si nécessaire, autoriser les corrections avec `/apply-review-fixes` ;
+7. tester manuellement la Deploy Preview Netlify ;
+8. accepter son intégration dans `develop` avec `/approve-preview`.
 
 ## Étape 1 — Collecte de la demande
 
-Cette première étape est disponible depuis **GitHub → Issues → New issue → Fonctionnalité assistée par IA**.
+La demande se crée depuis **GitHub → Issues → New issue → Fonctionnalité assistée par IA**. Le formulaire demande le problème à résoudre, les utilisateurs concernés, le parcours attendu, des critères de validation observables, l’impact probable sur les données et les contraintes éventuelles.
 
-Le formulaire demande :
+Le workflow `AI feature intake` vérifie l’auteur et les champs indispensables, normalise le brief et applique l’un de ces labels :
 
-- le problème à résoudre ;
-- les utilisateurs concernés ;
-- le résultat et le parcours attendus ;
-- des critères de validation observables ;
-- l’impact probable sur les données ;
-- les contraintes et références éventuelles.
+- `ai:ready-for-spec` : la demande est complète ;
+- `ai:needs-info` : des informations obligatoires manquent ;
+- `ai:needs-approval` : la demande vient d’un compte externe.
 
-À la création ou à la modification de l’Issue, le workflow `AI feature intake` :
-
-1. vérifie que les champs indispensables sont présents ;
-2. vérifie que l’auteur est propriétaire, membre ou collaborateur du dépôt ;
-3. transforme les réponses en brief initial normalisé ;
-4. maintient un commentaire de statut unique sur l’Issue ;
-5. applique l’un des labels suivants :
-   - `ai:ready-for-spec` : la demande peut être envoyée à l’agent de spécification ;
-   - `ai:needs-info` : des informations obligatoires manquent ;
-   - `ai:needs-approval` : la demande vient d’un compte externe ;
-6. transmet automatiquement une demande complète à l’agent de spécification.
+Une demande complète et autorisée est automatiquement transmise à l’agent de spécification.
 
 ## Étape 2 — Spécification assistée par IA
 
-Lorsqu’une demande reçoit le statut `ai:ready-for-spec`, le workflow `AI feature specification` :
+Le workflow `AI feature specification` fournit le brief et le dépôt à Codex dans un environnement en lecture seule. Il exige une réponse JSON structurée, puis publie une spécification en français sur l’Issue.
 
-1. contrôle à nouveau l’auteur et le label de l’Issue avant de consommer des crédits ;
-2. fournit à Codex le brief et le dépôt dans un environnement en lecture seule ;
-3. demande une spécification structurée en français, fondée sur les fichiers réellement présents ;
-4. valide la réponse avec un schéma JSON ;
-5. publie ou met à jour un commentaire unique sur l’Issue ;
-6. applique `ai:spec-ready` ou `ai:spec-needs-info`.
+La proposition couvre notamment le comportement, les fichiers concernés, l’approche technique, Supabase et les règles RLS, l’accessibilité et les tests. Elle reçoit `ai:spec-ready` ou `ai:spec-needs-info` et reste soumise à validation humaine.
 
-La spécification couvre le comportement, les fichiers concernés, l’approche technique, l’impact Supabase/RLS, l’accessibilité, les étapes d’implémentation et les tests. Elle reste soumise à validation humaine. Aucun code ni déploiement n’est encore produit.
+## Étape 3 — Approbation de la spécification
 
-## Étape 3 — Validation humaine
-
-Un propriétaire, membre ou collaborateur du dépôt approuve la proposition en ajoutant exactement ce commentaire dans l’Issue :
+Un propriétaire, membre ou collaborateur approuve la spécification en commentant exactement ceci sur l’Issue :
 
 ```text
 /approve-spec
 ```
 
-Le workflow `AI feature approval` contrôle que :
-
-- la commande vient d’un compte autorisé ;
-- la cible est bien une Issue et non une Pull Request ;
-- le label `ai:spec-ready` est encore présent ;
-- une spécification a réellement été publiée par le bot.
-
-Après validation, il ajoute `ai:spec-approved`, publie une confirmation et transmet l’Issue à l’agent de développement.
+Le workflow `AI feature approval` revalide l’auteur, la cible, le label et la présence de la spécification du bot. Il ajoute ensuite `ai:spec-approved` et déclenche l’implémentation.
 
 ## Étape 4 — Implémentation isolée
 
-L’agent développeur utilise la spécification approuvée et le dépôt `develop` pour produire un patch Git structuré. Il peut modifier le code applicatif dans sa copie de travail, mais n’a aucun jeton GitHub lui permettant de pousser ou de créer une PR.
+L’agent développeur travaille à partir de `develop` et de la spécification approuvée. Il peut modifier le code applicatif dans sa copie de travail, mais ne possède aucun jeton GitHub en écriture.
 
-Les chemins sensibles sont interdits dans cette première version : workflows GitHub, Supabase, fichiers d’environnement, dépendances et configuration Netlify. Si le besoin exige l’un de ces changements, l’agent publie un blocage au lieu de contourner la protection.
+Les chemins sensibles sont interdits : workflows GitHub, Supabase, fichiers d’environnement, dépendances et configuration Netlify. Si une fonctionnalité exige l’un de ces changements, l’agent signale un blocage.
 
-Le patch traverse ensuite deux environnements distincts :
+Le patch produit est réappliqué sur une copie propre dans un job sans secret, puis soumis au lint, au typecheck, aux tests du pipeline et au build. Un autre job ne disposant pas des secrets applicatifs crée alors `codex/issue-<numéro>`, pousse le patch validé et ouvre une Pull Request brouillon vers `develop`.
 
-1. un job sans secret et avec le dépôt en lecture seule réapplique le patch sur une copie propre, puis exécute lint, typecheck, tests du pipeline et build ;
-2. uniquement si tout réussit, un job séparé disposant des droits GitHub réapplique le même patch sans exécuter le code, crée `codex/issue-<numéro>`, pousse un commit et ouvre une Pull Request brouillon vers `develop`.
+## Étape 5 — CI, Deploy Preview et review IA
 
-L’Issue reçoit alors `ai:implementation-pr` et un lien vers la PR. La fusion et la mise en production restent manuelles.
+La Pull Request déclenche trois contrôles indépendants :
 
-Un mainteneur peut aussi relancer manuellement le workflow avec le numéro d’une Issue depuis l’onglet **Actions**, par exemple après la correction d’un workflow ou d’une configuration.
+- la CI GitHub `Lint, typecheck and build` ;
+- une Deploy Preview Netlify isolée ;
+- le workflow `AI feature review` en lecture seule.
+
+Le reviewer compare la spécification, l’Issue et le diff. Son verdict est attaché au SHA exact du dernier commit afin qu’une ancienne review ne puisse pas valider une nouvelle version.
+
+Il applique l’un des labels suivants :
+
+- `ai:review-passed` : aucun défaut actionnable n’a été trouvé ;
+- `ai:review-changes` : des corrections sont demandées ;
+- `ai:review-blocked` : la review ne peut pas conclure de manière fiable.
+
+Une review IA réussie n’est pas une validation produit : la preview doit encore être testée par un humain.
+
+## Étape 6 — Corrections autorisées
+
+Si la review demande des changements, un membre autorisé peut commenter exactement ceci sur la Pull Request :
+
+```text
+/apply-review-fixes
+```
+
+L’agent correcteur ne peut modifier que les fichiers déjà touchés par l’implémentation. Son patch repasse dans un environnement sans secret et dans les mêmes validations. En cas de succès, il est poussé sur la même branche, puis la CI et le reviewer sont explicitement relancés sur le nouveau SHA.
+
+Cette commande n’est acceptée que si la review courante demande réellement des changements.
+
+## Étape 7 — Acceptation humaine de la preview
+
+Lorsque la PR porte `ai:review-passed` et que Netlify affiche une Deploy Preview fonctionnelle, un membre autorisé doit ouvrir le lien, tester les critères de l’Issue et vérifier notamment le comportement mobile, les erreurs visibles et l’absence de régression évidente.
+
+Après ce test manuel, il peut commenter exactement ceci sur la Pull Request :
+
+```text
+/approve-preview
+```
+
+Le workflow `AI feature preview acceptance` revalide alors :
+
+- l’identité de la personne ayant commenté ;
+- la branche `codex/issue-<numéro>` et la cible `develop` ;
+- les labels de spécification, d’implémentation et de review ;
+- l’absence de correction ou de blocage en cours ;
+- une review positive attachée au SHA courant ;
+- la réussite de la CI sur ce SHA ;
+- la réussite de la Deploy Preview Netlify propre à cette PR ;
+- une URL de la forme `deploy-preview-<PR>--dev-synupsis.netlify.app`.
+
+Si tout est encore valide, la PR est passée hors brouillon, fusionnée par squash dans `develop`, l’Issue est clôturée avec `ai:integrated-dev` et la CI de `develop` est relancée explicitement.
+
+`/approve-preview` signifie donc « intégrer dans l’environnement de développement partagé ». Cette commande ne signifie jamais « mettre en production ».
 
 ## Sécurité
 
-Les Issues du dépôt étant publiques, l’appartenance de l’auteur est contrôlée avant la collecte puis à nouveau avant chaque appel au modèle. Le contenu de l’Issue est traité comme une donnée non fiable et les commentaires HTML sont retirés.
+Les Issues étant publiques, l’appartenance de l’auteur est contrôlée avant chaque opération sensible et avant chaque appel au modèle. Les textes produits par les utilisateurs sont traités comme des données non fiables et neutralisés avant leur insertion dans les prompts ou commentaires.
 
-Les agents de spécification et de développement ne disposent jamais d’un jeton GitHub en écriture. Pour l’implémentation, le code généré est en plus testé dans un job sans secret. Le job autorisé à pousser ne fait qu’appliquer le patch déjà validé et n’exécute aucun code généré.
+Les agents de spécification et de review sont en lecture seule. Les agents développeur et correcteur écrivent uniquement dans un espace isolé, sans droit GitHub en écriture. Le code généré est validé sans secret ; les jobs disposant d’un droit d’écriture ne font qu’appliquer un patch déjà contrôlé ou effectuer une opération GitHub déterministe.
 
-## Test local
+Chaque approbation humaine est une commande exacte et publique. Les reviews, corrections et acceptations sont liées au SHA complet afin d’empêcher qu’une autorisation ancienne soit réutilisée après modification du code.
+
+## Tests et relances
+
+Les scripts déterministes du pipeline se testent localement avec :
 
 ```bash
 yarn test:pipeline
 ```
 
-## Relance manuelle
+Les workflows de collecte, spécification, développement et review peuvent aussi être relancés manuellement depuis l’onglet **Actions** avec le numéro d’Issue ou de Pull Request demandé. Les commandes `/approve-spec`, `/apply-review-fixes` et `/approve-preview` restent volontairement publiques et humaines afin de conserver une trace d’autorisation explicite.
 
-Les workflows de collecte et de spécification acceptent un numéro d’Issue depuis l’onglet **Actions**. Relancer `AI feature intake` rejoue toute la chaîne si la demande est complète. Relancer directement `AI feature specification` ne rejoue que l’analyse. L’approbation, elle, exige volontairement la commande publique `/approve-spec` afin de conserver une trace humaine explicite dans l’Issue.
+## Frontière avec la production
 
-## Prochaine étape
+À ce stade, Netlify déploie automatiquement `develop` vers l’environnement de développement partagé et crée une Deploy Preview pour chaque Pull Request. Aucun environnement GitHub Production, aucun déploiement automatique de `main` et aucune promotion vers la production ne font partie de ce pipeline.
 
-Un agent de revue analysera la Pull Request, ses checks et le diff. Il pourra proposer ou appliquer des corrections avant que la PR soit présentée pour validation humaine et test de la preview Netlify.
+La prochaine étape sera de créer une fondation de production séparée : environnement Netlify dédié, secrets et Supabase de production distincts, remise à niveau contrôlée de `main`, règles de protection et commande de promotion indépendante. Cette étape devra conserver une validation humaine supplémentaire et ne réutilisera pas `/approve-preview`.


### PR DESCRIPTION
## Ce qui change

- ajoute la commande humaine exacte `/approve-preview` sur les PR générées ;
- revalide le SHA courant, la review IA positive, la CI GitHub et la Deploy Preview Netlify ;
- fusionne uniquement par squash dans `develop`, clôture l’Issue et relance explicitement la CI ;
- documente les étapes de review, correction et acceptation, avec une frontière explicite avant la production.

## Pourquoi

Cette étape transforme la Deploy Preview en véritable porte de validation produit pour un membre non développeur, sans donner aux agents un accès direct à la production.

## Validation

- `yarn test:pipeline` — 47 tests
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- parsing YAML de tous les workflows
- `git diff --check`
