### PR TITLE
fix: allow pipeline PR label updates

### DIFF
--- a/.github/scripts/workflow-permissions.test.mjs
+++ b/.github/scripts/workflow-permissions.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+function workflowJob(workflowPath, jobName) {
+  const lines = readFileSync(workflowPath, 'utf8').split('\n')
+  const start = lines.findIndex((line) => line === `  ${jobName}:`)
+  assert.notEqual(start, -1, `Job ${jobName} is missing from ${workflowPath}.`)
+  const nextJob = lines.findIndex((line, index) =>
+    index > start && /^  [a-z][a-z0-9_-]*:$/.test(line),
+  )
+  return lines.slice(start, nextJob === -1 ? undefined : nextJob).join('\n')
+}
+
+test('PR comment authorization jobs can update Pull Request labels', () => {
+  const workflows = [
+    '.github/workflows/ai-feature-correction.yml',
+    '.github/workflows/ai-feature-preview-acceptance.yml',
+  ]
+
+  for (const workflow of workflows) {
+    const authorizeJob = workflowJob(workflow, 'authorize')
+    assert.match(authorizeJob, /^      issues: write$/m)
+    assert.match(authorizeJob, /^      pull-requests: write$/m)
+  }
+})

--- a/.github/workflows/ai-feature-correction.yml
+++ b/.github/workflows/ai-feature-correction.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     outputs:
       approval_status: ${{ steps.authorize.outputs.approval_status }}
       pull_request_number: ${{ steps.authorize.outputs.pull_request_number }}

--- a/.github/workflows/ai-feature-preview-acceptance.yml
+++ b/.github/workflows/ai-feature-preview-acceptance.yml
@@ -23,7 +23,7 @@ jobs:
       checks: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: read
     outputs:
       approval_status: ${{ steps.authorize.outputs.approval_status }}


### PR DESCRIPTION
## Correctif

- accorde `pull-requests: write` uniquement aux jobs qui enregistrent une approbation humaine et ajoutent un label sur une Pull Request ;
- conserve tous les autres droits minimaux existants ;
- ajoute un test de non-régression couvrant les workflows de correction et d’acceptation de preview.

## Cause

GitHub a refusé l’ajout du label `ai:fix-in-progress` avec `403 Resource not accessible by integration`. Modifier les labels d’une Pull Request exige simultanément `issues: write` et `pull-requests: write` pour le `GITHUB_TOKEN` du job.

## Impact

La commande `/apply-review-fixes` pourra enregistrer son autorisation et démarrer l’agent correcteur. Le futur `/approve-preview` ne rencontrera pas le même blocage.

## Validation

- `yarn test:pipeline` — 48 tests
- `yarn lint`
- parsing YAML de tous les workflows
- `git diff --check`
