### PR TITLE
fix: allow trusted automated AI reviews

### DIFF
--- a/.github/scripts/workflow-permissions.test.mjs
+++ b/.github/scripts/workflow-permissions.test.mjs
@@ -24,3 +24,10 @@ test('PR comment authorization jobs can update Pull Request labels', () => {
     assert.match(authorizeJob, /^      pull-requests: write$/m)
   }
 })
+
+test('automated AI reviews trust only the GitHub Actions bot', () => {
+  const reviewJob = workflowJob('.github/workflows/ai-feature-review.yml', 'review')
+
+  assert.match(reviewJob, /^          allow-bot-users: 'github-actions\[bot\]'$/m)
+  assert.doesNotMatch(reviewJob, /^          allow-bots: true$/m)
+})

--- a/.github/workflows/ai-feature-review.yml
+++ b/.github/workflows/ai-feature-review.yml
@@ -79,6 +79,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          # The correction publisher dispatches this workflow with its GITHUB_TOKEN.
+          allow-bot-users: 'github-actions[bot]'
           prompt-file: .github/codex/runtime-review-prompt.md
           model: gpt-5.6-sol
           effort: high


### PR DESCRIPTION
## Correctif

- autorise uniquement `github-actions[bot]` à lancer `openai/codex-action` dans le workflow de review ;
- conserve le reviewer en lecture seule et toutes les revalidations de PR, Issue, labels, branche et SHA ;
- ajoute un test qui exige cette identité exacte et interdit l’option globale `allow-bots: true`.

## Cause

Après une correction validée, le pipeline relance la review avec son `GITHUB_TOKEN`. `openai/codex-action` refuse par défaut cet acteur et arrêtait le run avant l’appel au modèle.

## Impact

Les corrections générées pourront désormais être automatiquement reviewées sur leur nouveau SHA. Aucun bot supplémentaire et aucun droit d’écriture ne sont accordés au reviewer.

## Validation

- `yarn test:pipeline` — 49 tests
- `yarn lint`
- parsing YAML de tous les workflows
- `git diff --check`
