### PR TITLE
feat: add guarded production promotion pipeline

### DIFF
--- a/.github/scripts/production-release.mjs
+++ b/.github/scripts/production-release.mjs
@@ -1,0 +1,719 @@
+const PREPARE_PRODUCTION_COMMAND = '/prepare-production'
+const APPROVE_PRODUCTION_COMMAND = '/approve-production'
+const RELEASE_METADATA_MARKER = '<!-- synupsis-production-release:v1 -->'
+const RELEASE_APPROVAL_MARKER = '<!-- synupsis-production-approval:v1 -->'
+const RELEASE_RESULT_MARKER = '<!-- synupsis-production-result:v1 -->'
+const RELEASE_CONTROL_LABEL = 'ai:release-control'
+const CI_CHECK_NAME = 'Lint, typecheck and build'
+const CI_WORKFLOW_NAME = 'CI'
+const GITHUB_ACTIONS_BOT_LOGIN = 'github-actions[bot]'
+const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
+
+const RELEASE_LABELS = {
+  candidate: {
+    name: 'ai:release-candidate',
+    color: '0969da',
+    description: 'Snapshot figé de develop proposé pour la production',
+  },
+  database: {
+    name: 'ai:release-db-changes',
+    color: 'fbca04',
+    description: 'La release contient des changements Supabase à vérifier',
+  },
+  approved: {
+    name: 'ai:release-approved',
+    color: '1f883d',
+    description: 'La release a reçu sa validation humaine de production',
+  },
+  promoted: {
+    name: 'ai:production-promoted',
+    color: '8250df',
+    description: 'La release a été fusionnée dans la branche main',
+  },
+}
+
+function normalizePositiveInteger(value, name) {
+  const normalized = Number(value)
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throw new Error(`The ${name} input must be a positive integer.`)
+  }
+  return normalized
+}
+
+function validateHeadSha(value, name = 'head SHA') {
+  if (typeof value !== 'string' || !/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error(`The ${name} is invalid.`)
+  }
+  return value.toLowerCase()
+}
+
+function isTrustedAssociation(association = '') {
+  return TRUSTED_ASSOCIATIONS.has(association.toUpperCase())
+}
+
+function labelsOf(item) {
+  return new Set(
+    (item.labels ?? [])
+      .map((label) => typeof label === 'string' ? label : label.name)
+      .filter(Boolean),
+  )
+}
+
+function neutralizeMentions(value) {
+  return value.replaceAll('@', '@\u200b')
+}
+
+function sanitizeLine(value, maxLength = 160) {
+  return neutralizeMentions(String(value ?? ''))
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+function latestByDate(items, dateFields) {
+  return [...items].sort((left, right) => {
+    const leftDate = dateFields.map((field) => Date.parse(left[field] ?? '')).find(Number.isFinite) ?? 0
+    const rightDate = dateFields.map((field) => Date.parse(right[field] ?? '')).find(Number.isFinite) ?? 0
+    return rightDate - leftDate
+  })[0]
+}
+
+function dateParts(now) {
+  const iso = now.toISOString()
+  return {
+    day: iso.slice(0, 10),
+    compact: iso.slice(0, 19).replaceAll('-', '').replaceAll(':', '').replace('T', '-'),
+  }
+}
+
+function formatCommit(commit) {
+  const sha = validateHeadSha(commit.sha, 'commit SHA')
+  const subject = sanitizeLine(commit.commit?.message?.split('\n')[0] ?? 'Commit sans titre')
+  return `- \`${sha.slice(0, 12)}\` ${subject}`
+}
+
+function summarizeReleaseFiles(files = []) {
+  const filenames = files.map((file) => file.filename).filter(Boolean)
+  return {
+    migrations: filenames.filter((filename) => filename.startsWith('supabase/migrations/')),
+    supabaseFunctions: filenames.filter((filename) => filename.startsWith('supabase/functions/')),
+    workflows: filenames.filter((filename) => filename.startsWith('.github/workflows/')),
+    dependencies: filenames.filter((filename) => ['package.json', 'yarn.lock', '.nvmrc'].includes(filename)),
+  }
+}
+
+function formatFileList(files, emptyLabel = 'Aucun') {
+  if (files.length === 0) {
+    return `- ${emptyLabel}`
+  }
+  return files.slice(0, 20).map((filename) => `- \`${sanitizeLine(filename, 240)}\``).join('\n')
+}
+
+export function isPrepareProductionCommand(body = '') {
+  return body === PREPARE_PRODUCTION_COMMAND
+}
+
+export function isApproveProductionCommand(body = '') {
+  return body === APPROVE_PRODUCTION_COMMAND
+}
+
+export function releaseHeadMarker(headSha) {
+  return `<!-- synupsis-production-head:${validateHeadSha(headSha)} -->`
+}
+
+export function releaseBaseMarker(baseSha) {
+  return `<!-- synupsis-production-base:${validateHeadSha(baseSha, 'base SHA')} -->`
+}
+
+export function releaseControlIssueMarker(issueNumber) {
+  return `<!-- synupsis-production-control-issue:${normalizePositiveInteger(issueNumber, 'control issue number')} -->`
+}
+
+function releaseBranchName(now, headSha) {
+  return `release/${dateParts(now).compact}-${validateHeadSha(headSha).slice(0, 12)}`
+}
+
+function releaseTitle(now) {
+  return `Release production ${dateParts(now).day}`
+}
+
+export function buildReleasePullRequestBody({
+  controlIssueNumber,
+  baseSha,
+  headSha,
+  compare,
+}) {
+  const files = compare.files ?? []
+  const commits = compare.commits ?? []
+  const risks = summarizeReleaseFiles(files)
+  const commitLines = commits.slice(-30).map(formatCommit)
+  if (commits.length > 30) {
+    commitLines.unshift(`- … ${commits.length - 30} commits plus anciens sont également inclus.`)
+  }
+
+  return [
+    RELEASE_METADATA_MARKER,
+    releaseHeadMarker(headSha),
+    releaseBaseMarker(baseSha),
+    releaseControlIssueMarker(controlIssueNumber),
+    '## Candidat de production figé',
+    '',
+    `Cette Pull Request promeut le snapshot \`${headSha.slice(0, 12)}\` de \`develop\` vers \`main\`.`,
+    '',
+    `- Base \`main\` enregistrée : \`${baseSha.slice(0, 12)}\``,
+    `- Commits inclus : **${compare.ahead_by ?? commits.length}**`,
+    `- Fichiers modifiés : **${files.length}**`,
+    `- Issue de contrôle : #${controlIssueNumber}`,
+    '',
+    '### Changements sensibles à vérifier',
+    '',
+    `- Migrations Supabase : **${risks.migrations.length}**`,
+    `- Fonctions Supabase : **${risks.supabaseFunctions.length}**`,
+    `- Workflows GitHub : **${risks.workflows.length}**`,
+    `- Dépendances/runtime : **${risks.dependencies.length}**`,
+    '',
+    '#### Migrations Supabase',
+    '',
+    formatFileList(risks.migrations),
+    '',
+    '### Commits inclus',
+    '',
+    commitLines.length > 0 ? commitLines.join('\n') : '- Aucun commit listé par GitHub.',
+    '',
+    '### Validation obligatoire',
+    '',
+    '- [ ] La CI de cette branche de release est verte.',
+    '- [ ] `https://dev-synupsis.netlify.app` a été testé par un humain.',
+    '- [ ] Les migrations et changements de configuration ont été relus.',
+    '- [ ] La base `main` et le SHA de release n’ont pas changé.',
+    '',
+    'Après validation, commenter exactement `/approve-production` sur cette Pull Request.',
+    '',
+    '> La fusion utilisera un merge commit. Ne pas utiliser Squash and merge pour une release.',
+  ].join('\n')
+}
+
+export function buildReleaseMetadataComment({ controlIssueNumber, baseSha, headSha }) {
+  return [
+    RELEASE_METADATA_MARKER,
+    releaseHeadMarker(headSha),
+    releaseBaseMarker(baseSha),
+    releaseControlIssueMarker(controlIssueNumber),
+    '### Métadonnées de release',
+    '',
+    `Snapshot figé : \`${headSha}\``,
+    '',
+    `Base de production : \`${baseSha}\``,
+    '',
+    'Ces valeurs sont enregistrées par le pipeline et seront revalidées juste avant la fusion.',
+  ].join('\n')
+}
+
+export function buildReleaseApprovalComment({ headSha, baseSha }) {
+  return [
+    RELEASE_APPROVAL_MARKER,
+    releaseHeadMarker(headSha),
+    releaseBaseMarker(baseSha),
+    '### Mise en production approuvée',
+    '',
+    `La validation humaine est enregistrée pour le snapshot \`${headSha.slice(0, 12)}\` et la base \`main\` \`${baseSha.slice(0, 12)}\`.`,
+    '',
+    'Le pipeline va revalider ces deux SHA et la CI avant de fusionner la release dans `main` par merge commit.',
+  ].join('\n')
+}
+
+async function ensureLabel(github, owner, repo, label) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: label.name })
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error
+    }
+    try {
+      await github.rest.issues.createLabel({ owner, repo, ...label })
+    } catch (createError) {
+      if (createError.status !== 422) {
+        throw createError
+      }
+    }
+  }
+}
+
+async function getReleaseControlIssue({ github, context, issueNumber }) {
+  const normalizedIssueNumber = normalizePositiveInteger(issueNumber, 'control issue number')
+  const { owner, repo } = context.repo
+  const response = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: normalizedIssueNumber,
+  })
+  const issue = response.data
+  if (issue.pull_request) {
+    throw new Error(`#${normalizedIssueNumber} must be an Issue, not a Pull Request.`)
+  }
+  if (issue.state !== 'open') {
+    throw new Error(`Release control Issue #${normalizedIssueNumber} is not open.`)
+  }
+  if (!isTrustedAssociation(issue.author_association)) {
+    throw new Error(`Release control Issue #${normalizedIssueNumber} was not created by a trusted member.`)
+  }
+  if (!labelsOf(issue).has(RELEASE_CONTROL_LABEL)) {
+    throw new Error(`Release control Issue #${normalizedIssueNumber} is missing label ${RELEASE_CONTROL_LABEL}.`)
+  }
+  return issue
+}
+
+function findOpenReleasePullRequest(pullRequests) {
+  return pullRequests.find((pullRequest) =>
+    pullRequest.state === 'open'
+    && pullRequest.base?.ref === 'main'
+    && pullRequest.head?.ref?.startsWith('release/')
+    && labelsOf(pullRequest).has(RELEASE_LABELS.candidate.name),
+  )
+}
+
+export async function handleProductionPreparation({ github, context, core, now = new Date() }) {
+  const eventIssue = context.payload.issue
+  const comment = context.payload.comment
+  if (!eventIssue || !comment || !isPrepareProductionCommand(comment.body)) {
+    core.info('This comment is not a production preparation command.')
+    core.setOutput('preparation_status', 'ignored')
+    return
+  }
+  if (eventIssue.pull_request) {
+    core.warning('Production preparation commands are accepted only on the release control Issue.')
+    core.setOutput('preparation_status', 'rejected')
+    return
+  }
+  if (!isTrustedAssociation(comment.author_association)) {
+    core.warning('The production preparation command was posted by an untrusted account.')
+    core.setOutput('preparation_status', 'rejected')
+    return
+  }
+
+  const { owner, repo } = context.repo
+  const controlIssueNumber = normalizePositiveInteger(eventIssue.number, 'control issue number')
+  await getReleaseControlIssue({ github, context, issueNumber: controlIssueNumber })
+
+  const openPullRequestsResponse = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    base: 'main',
+    per_page: 100,
+  })
+  const existingRelease = findOpenReleasePullRequest(openPullRequestsResponse.data)
+  if (existingRelease) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: controlIssueNumber,
+      body: `Une release est déjà en attente : [#${existingRelease.number}](${existingRelease.html_url}).`,
+    })
+    core.setOutput('preparation_status', RELEASE_LABELS.candidate.name)
+    core.setOutput('pull_request_number', String(existingRelease.number))
+    core.setOutput('release_branch', existingRelease.head.ref)
+    core.setOutput('head_sha', existingRelease.head.sha)
+    return
+  }
+
+  const [developRefResponse, mainRefResponse] = await Promise.all([
+    github.rest.git.getRef({ owner, repo, ref: 'heads/develop' }),
+    github.rest.git.getRef({ owner, repo, ref: 'heads/main' }),
+  ])
+  const headSha = validateHeadSha(developRefResponse.data.object.sha, 'develop SHA')
+  const baseSha = validateHeadSha(mainRefResponse.data.object.sha, 'main SHA')
+  if (headSha === baseSha) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: controlIssueNumber,
+      body: '`develop` et `main` pointent déjà sur le même commit : aucune release à préparer.',
+    })
+    core.setOutput('preparation_status', 'no-changes')
+    return
+  }
+
+  const compareResponse = await github.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: 'main...develop',
+    per_page: 100,
+  })
+  const compare = compareResponse.data
+  if (!['ahead', 'diverged'].includes(compare.status) || Number(compare.ahead_by) <= 0) {
+    throw new Error('develop does not contain releasable commits ahead of main.')
+  }
+
+  const releaseBranch = releaseBranchName(now, headSha)
+  await github.rest.git.createRef({
+    owner,
+    repo,
+    ref: `refs/heads/${releaseBranch}`,
+    sha: headSha,
+  })
+
+  let pullRequest
+  try {
+    const pullRequestResponse = await github.rest.pulls.create({
+      owner,
+      repo,
+      base: 'main',
+      head: releaseBranch,
+      title: releaseTitle(now),
+      body: buildReleasePullRequestBody({ controlIssueNumber, baseSha, headSha, compare }),
+      draft: true,
+      maintainer_can_modify: false,
+    })
+    pullRequest = pullRequestResponse.data
+  } catch (error) {
+    try {
+      await github.rest.git.deleteRef({ owner, repo, ref: `heads/${releaseBranch}` })
+    } catch {
+      // Keep the original Pull Request creation error.
+    }
+    throw error
+  }
+
+  await ensureLabel(github, owner, repo, RELEASE_LABELS.candidate)
+  const releaseLabels = [RELEASE_LABELS.candidate.name]
+  const risks = summarizeReleaseFiles(compare.files ?? [])
+  if (risks.migrations.length > 0 || risks.supabaseFunctions.length > 0) {
+    await ensureLabel(github, owner, repo, RELEASE_LABELS.database)
+    releaseLabels.push(RELEASE_LABELS.database.name)
+  }
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullRequest.number,
+    labels: releaseLabels,
+  })
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullRequest.number,
+    body: buildReleaseMetadataComment({ controlIssueNumber, baseSha, headSha }),
+  })
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: controlIssueNumber,
+    body: [
+      '### Release de production préparée',
+      '',
+      `La Pull Request [#${pullRequest.number}](${pullRequest.html_url}) fige \`develop\` au commit \`${headSha.slice(0, 12)}\`.`,
+      '',
+      'La CI a été déclenchée explicitement. Aucun déploiement de production n’a encore lieu.',
+    ].join('\n'),
+  })
+  await github.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id: 'ci.yml',
+    ref: releaseBranch,
+  })
+
+  core.setOutput('preparation_status', RELEASE_LABELS.candidate.name)
+  core.setOutput('pull_request_number', String(pullRequest.number))
+  core.setOutput('release_branch', releaseBranch)
+  core.setOutput('head_sha', headSha)
+  core.setOutput('base_sha', baseSha)
+}
+
+function assertReleasePullRequest({ pullRequest, context }) {
+  const expectedRepository = `${context.repo.owner}/${context.repo.repo}`
+  if (pullRequest.state !== 'open') {
+    throw new Error(`Pull Request #${pullRequest.number} is not open.`)
+  }
+  if (pullRequest.base?.ref !== 'main') {
+    throw new Error(`Pull Request #${pullRequest.number} does not target main.`)
+  }
+  if (pullRequest.head?.repo?.full_name !== expectedRepository) {
+    throw new Error(`Pull Request #${pullRequest.number} does not come from the trusted repository.`)
+  }
+  if (!/^release\/\d{8}-\d{6}-[0-9a-f]{12}$/i.test(pullRequest.head?.ref ?? '')) {
+    throw new Error(`Pull Request #${pullRequest.number} does not use a trusted release branch.`)
+  }
+  if (!labelsOf(pullRequest).has(RELEASE_LABELS.candidate.name)) {
+    throw new Error(`Pull Request #${pullRequest.number} is not labelled ${RELEASE_LABELS.candidate.name}.`)
+  }
+}
+
+function parseControlIssueNumber(body) {
+  const match = body.match(/<!-- synupsis-production-control-issue:(\d+) -->/)
+  return match ? normalizePositiveInteger(match[1], 'control issue number') : null
+}
+
+function findReleaseMetadata(comments, pullRequest) {
+  const comment = comments.find((candidate) =>
+    candidate.user?.type === 'Bot'
+    && candidate.user?.login === GITHUB_ACTIONS_BOT_LOGIN
+    && candidate.body?.includes(RELEASE_METADATA_MARKER)
+    && candidate.body?.includes(releaseHeadMarker(pullRequest.head.sha)),
+  )
+  if (!comment) {
+    throw new Error(`Pull Request #${pullRequest.number} has no trusted release metadata for its current SHA.`)
+  }
+  const baseMatch = comment.body.match(/<!-- synupsis-production-base:([0-9a-f]{40}) -->/i)
+  const baseSha = baseMatch ? validateHeadSha(baseMatch[1], 'recorded main SHA') : null
+  const controlIssueNumber = parseControlIssueNumber(comment.body)
+  if (!baseSha || !controlIssueNumber) {
+    throw new Error(`Pull Request #${pullRequest.number} contains incomplete release metadata.`)
+  }
+  return { comment, baseSha, controlIssueNumber }
+}
+
+export async function verifyReleaseChecks({ github, owner, repo, pullRequest }) {
+  const checkRunsResponse = await github.rest.checks.listForRef({
+    owner,
+    repo,
+    ref: pullRequest.head.sha,
+    per_page: 100,
+  })
+  const ciCheck = latestByDate(
+    checkRunsResponse.data.check_runs.filter((checkRun) =>
+      checkRun.name === CI_CHECK_NAME && checkRun.app?.slug === 'github-actions',
+    ),
+    ['completed_at', 'started_at'],
+  )
+  if (!ciCheck || ciCheck.status !== 'completed' || ciCheck.conclusion !== 'success') {
+    throw new Error(`Pull Request #${pullRequest.number} does not have a successful current CI check.`)
+  }
+
+  const workflowRunsResponse = await github.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    head_sha: pullRequest.head.sha,
+    per_page: 100,
+  })
+  const currentRun = latestByDate(
+    workflowRunsResponse.data.workflow_runs.filter((run) =>
+      run.name === CI_WORKFLOW_NAME
+      && run.head_sha?.toLowerCase() === pullRequest.head.sha.toLowerCase()
+      && run.head_branch === pullRequest.head.ref
+      && ['pull_request', 'workflow_dispatch'].includes(run.event),
+    ),
+    ['updated_at', 'run_started_at', 'created_at'],
+  )
+  if (!currentRun || currentRun.status !== 'completed' || currentRun.conclusion !== 'success') {
+    throw new Error(`Pull Request #${pullRequest.number} does not have a successful CI workflow run for its release branch.`)
+  }
+  return { checkUrl: ciCheck.details_url, workflowUrl: currentRun.html_url }
+}
+
+async function getReleaseContext({
+  github,
+  context,
+  pullRequestNumber,
+  expectedHeadSha,
+  expectedBaseSha,
+  requireApprovalComment = false,
+}) {
+  const normalizedPullRequestNumber = normalizePositiveInteger(pullRequestNumber, 'pull request number')
+  const { owner, repo } = context.repo
+  const pullRequestResponse = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: normalizedPullRequestNumber,
+  })
+  const pullRequest = pullRequestResponse.data
+  assertReleasePullRequest({ pullRequest, context })
+  const headSha = validateHeadSha(pullRequest.head.sha)
+  if (expectedHeadSha && headSha !== validateHeadSha(expectedHeadSha, 'expected head SHA')) {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} changed during production approval.`)
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: normalizedPullRequestNumber,
+    per_page: 100,
+  })
+  const metadata = findReleaseMetadata(comments, pullRequest)
+  if (expectedBaseSha && metadata.baseSha !== validateHeadSha(expectedBaseSha, 'expected base SHA')) {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} has unexpected main metadata.`)
+  }
+  await getReleaseControlIssue({
+    github,
+    context,
+    issueNumber: metadata.controlIssueNumber,
+  })
+
+  const mainRefResponse = await github.rest.git.getRef({ owner, repo, ref: 'heads/main' })
+  const currentMainSha = validateHeadSha(mainRefResponse.data.object.sha, 'current main SHA')
+  if (currentMainSha !== metadata.baseSha) {
+    throw new Error(`main changed after Pull Request #${normalizedPullRequestNumber} was prepared.`)
+  }
+  if (pullRequest.mergeable === false || pullRequest.mergeable_state === 'dirty') {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} has merge conflicts.`)
+  }
+
+  const approvalComment = comments.find((candidate) =>
+    candidate.user?.type === 'Bot'
+    && candidate.user?.login === GITHUB_ACTIONS_BOT_LOGIN
+    && candidate.body?.includes(RELEASE_APPROVAL_MARKER)
+    && candidate.body?.includes(releaseHeadMarker(headSha))
+    && candidate.body?.includes(releaseBaseMarker(metadata.baseSha)),
+  )
+  if (requireApprovalComment && !approvalComment) {
+    throw new Error(`Pull Request #${normalizedPullRequestNumber} has no production approval for its current SHA.`)
+  }
+
+  const checks = await verifyReleaseChecks({ github, owner, repo, pullRequest })
+  return {
+    owner,
+    repo,
+    pullRequestNumber: normalizedPullRequestNumber,
+    pullRequest,
+    headSha,
+    approvalComment,
+    ...metadata,
+    ...checks,
+  }
+}
+
+export async function handleProductionApproval({ github, context, core }) {
+  const eventIssue = context.payload.issue
+  const comment = context.payload.comment
+  if (!eventIssue || !comment || !isApproveProductionCommand(comment.body)) {
+    core.info('This comment is not a production approval command.')
+    core.setOutput('approval_status', 'ignored')
+    return
+  }
+  if (!eventIssue.pull_request) {
+    core.warning('Production approvals are accepted only on release Pull Requests.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+  if (!isTrustedAssociation(comment.author_association)) {
+    core.warning('The production approval command was posted by an untrusted account.')
+    core.setOutput('approval_status', 'rejected')
+    return
+  }
+
+  const release = await getReleaseContext({
+    github,
+    context,
+    pullRequestNumber: eventIssue.number,
+  })
+  await ensureLabel(github, release.owner, release.repo, RELEASE_LABELS.approved)
+  await github.rest.issues.addLabels({
+    owner: release.owner,
+    repo: release.repo,
+    issue_number: release.pullRequestNumber,
+    labels: [RELEASE_LABELS.approved.name],
+  })
+  if (!release.approvalComment) {
+    await github.rest.issues.createComment({
+      owner: release.owner,
+      repo: release.repo,
+      issue_number: release.pullRequestNumber,
+      body: buildReleaseApprovalComment({ headSha: release.headSha, baseSha: release.baseSha }),
+    })
+  }
+
+  core.setOutput('approval_status', RELEASE_LABELS.approved.name)
+  core.setOutput('pull_request_number', String(release.pullRequestNumber))
+  core.setOutput('head_sha', release.headSha)
+  core.setOutput('base_sha', release.baseSha)
+  core.setOutput('control_issue_number', String(release.controlIssueNumber))
+}
+
+export async function mergeApprovedProduction({
+  github,
+  context,
+  core,
+  pullRequestNumber,
+  expectedHeadSha,
+  expectedBaseSha,
+}) {
+  const release = await getReleaseContext({
+    github,
+    context,
+    pullRequestNumber,
+    expectedHeadSha,
+    expectedBaseSha,
+    requireApprovalComment: true,
+  })
+
+  if (release.pullRequest.draft) {
+    await github.graphql(
+      `mutation MarkPullRequestReady($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { isDraft }
+        }
+      }`,
+      { pullRequestId: release.pullRequest.node_id },
+    )
+  }
+
+  const title = sanitizeLine(release.pullRequest.title, 180)
+  const mergeResponse = await github.rest.pulls.merge({
+    owner: release.owner,
+    repo: release.repo,
+    pull_number: release.pullRequestNumber,
+    sha: release.headSha,
+    merge_method: 'merge',
+    commit_title: `${title} (#${release.pullRequestNumber})`,
+    commit_message: `Promotion validée du snapshot develop ${release.headSha}.`,
+  })
+  if (!mergeResponse.data.merged || !mergeResponse.data.sha) {
+    throw new Error(
+      `GitHub refused to merge Pull Request #${release.pullRequestNumber}: ${mergeResponse.data.message ?? 'unknown reason'}.`,
+    )
+  }
+
+  await ensureLabel(github, release.owner, release.repo, RELEASE_LABELS.promoted)
+  await github.rest.issues.addLabels({
+    owner: release.owner,
+    repo: release.repo,
+    issue_number: release.pullRequestNumber,
+    labels: [RELEASE_LABELS.promoted.name],
+  })
+
+  const resultBody = [
+    RELEASE_RESULT_MARKER,
+    '### Release fusionnée dans `main`',
+    '',
+    `Le snapshot \`${release.headSha.slice(0, 12)}\` a été fusionné par merge commit \`${mergeResponse.data.sha.slice(0, 12)}\`.`,
+    '',
+    'Netlify et Supabase peuvent maintenant démarrer leurs déploiements liés à `main`. Leur réussite doit encore être vérifiée avant de considérer la production comme validée.',
+  ].join('\n')
+  await github.rest.issues.createComment({
+    owner: release.owner,
+    repo: release.repo,
+    issue_number: release.pullRequestNumber,
+    body: resultBody,
+  })
+  await github.rest.issues.createComment({
+    owner: release.owner,
+    repo: release.repo,
+    issue_number: release.controlIssueNumber,
+    body: [
+      '### Promotion vers la production déclenchée',
+      '',
+      `La Pull Request [#${release.pullRequestNumber}](${release.pullRequest.html_url}) a été fusionnée dans \`main\`.`,
+      '',
+      `Merge commit : \`${mergeResponse.data.sha.slice(0, 12)}\`.`,
+      '',
+      'Vérifier maintenant les déploiements Supabase et Netlify ainsi que le smoke test de `https://synupsis.com`.',
+    ].join('\n'),
+  })
+
+  try {
+    await github.rest.git.deleteRef({
+      owner: release.owner,
+      repo: release.repo,
+      ref: `heads/${release.pullRequest.head.ref}`,
+    })
+  } catch (error) {
+    if (![404, 422].includes(error.status)) {
+      throw error
+    }
+  }
+
+  core.setOutput('promotion_status', RELEASE_LABELS.promoted.name)
+  core.setOutput('merge_sha', mergeResponse.data.sha)
+  core.info(`Pull Request #${release.pullRequestNumber} merged into main.`)
+}

--- a/.github/scripts/production-release.test.mjs
+++ b/.github/scripts/production-release.test.mjs
@@ -1,0 +1,366 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildReleaseApprovalComment,
+  buildReleaseMetadataComment,
+  handleProductionApproval,
+  handleProductionPreparation,
+  isApproveProductionCommand,
+  isPrepareProductionCommand,
+  mergeApprovedProduction,
+  releaseBaseMarker,
+  releaseHeadMarker,
+  verifyReleaseChecks,
+} from './production-release.mjs'
+
+const headSha = 'a'.repeat(40)
+const baseSha = 'b'.repeat(40)
+const mergeSha = 'c'.repeat(40)
+const controlIssueNumber = 42
+const releaseBranch = 'release/20260721-120000-aaaaaaaaaaaa'
+
+const releasePullRequest = {
+  number: 31,
+  node_id: 'PR_kwDORelease',
+  state: 'open',
+  draft: true,
+  mergeable: true,
+  mergeable_state: 'clean',
+  title: 'Release production 2026-07-21',
+  html_url: 'https://github.com/synupsis/synupsis-web/pull/31',
+  labels: [{ name: 'ai:release-candidate' }],
+  head: {
+    ref: releaseBranch,
+    sha: headSha,
+    repo: { full_name: 'synupsis/synupsis-web' },
+  },
+  base: { ref: 'main' },
+}
+
+const releaseControlIssue = {
+  number: controlIssueNumber,
+  state: 'open',
+  author_association: 'OWNER',
+  labels: [{ name: 'ai:release-control' }],
+}
+
+const metadataComment = {
+  user: { type: 'Bot', login: 'github-actions[bot]' },
+  created_at: '2026-07-21T12:00:00Z',
+  body: buildReleaseMetadataComment({ controlIssueNumber, baseSha, headSha }),
+}
+
+const approvalComment = {
+  user: { type: 'Bot', login: 'github-actions[bot]' },
+  created_at: '2026-07-21T12:05:00Z',
+  body: buildReleaseApprovalComment({ headSha, baseSha }),
+}
+
+function successfulCheckRuns() {
+  return [{
+    name: 'Lint, typecheck and build',
+    status: 'completed',
+    conclusion: 'success',
+    details_url: 'https://github.com/synupsis/synupsis-web/actions/runs/100',
+    completed_at: '2026-07-21T12:03:00Z',
+    app: { slug: 'github-actions' },
+  }]
+}
+
+function successfulWorkflowRuns() {
+  return [{
+    name: 'CI',
+    event: 'workflow_dispatch',
+    status: 'completed',
+    conclusion: 'success',
+    head_sha: headSha,
+    head_branch: releaseBranch,
+    html_url: 'https://github.com/synupsis/synupsis-web/actions/runs/100',
+    updated_at: '2026-07-21T12:03:00Z',
+  }]
+}
+
+function compareResult() {
+  return {
+    status: 'ahead',
+    ahead_by: 2,
+    commits: [
+      { sha: 'd'.repeat(40), commit: { message: 'feat: add first release change' } },
+      { sha: headSha, commit: { message: 'fix: complete the release\n\nDetails' } },
+    ],
+    files: [
+      { filename: 'app/pages/index.vue' },
+      { filename: 'supabase/migrations/20260721120000_add_release.sql' },
+    ],
+  }
+}
+
+function productionGithub({
+  currentPullRequest = releasePullRequest,
+  currentControlIssue = releaseControlIssue,
+  comments = [metadataComment],
+  checkRuns = successfulCheckRuns(),
+  workflowRuns = successfulWorkflowRuns(),
+  mainSha = baseSha,
+  developSha = headSha,
+  openPullRequests = [],
+  compare = compareResult(),
+} = {}) {
+  const calls = {
+    addedLabels: [],
+    comments: [],
+    createdPullRequests: [],
+    createdRefs: [],
+    deletedRefs: [],
+    dispatches: [],
+    graphql: [],
+    merges: [],
+  }
+
+  const github = {
+    rest: {
+      actions: {
+        createWorkflowDispatch: async (input) => calls.dispatches.push(input),
+        listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: workflowRuns } }),
+      },
+      checks: {
+        listForRef: async () => ({ data: { check_runs: checkRuns } }),
+      },
+      git: {
+        createRef: async (input) => calls.createdRefs.push(input),
+        deleteRef: async (input) => calls.deletedRefs.push(input),
+        getRef: async ({ ref }) => ({
+          data: { object: { sha: ref === 'heads/develop' ? developSha : mainSha } },
+        }),
+      },
+      issues: {
+        addLabels: async (input) => calls.addedLabels.push(input),
+        createComment: async (input) => calls.comments.push(input),
+        createLabel: async () => {},
+        get: async ({ issue_number: issueNumber }) => {
+          assert.equal(issueNumber, controlIssueNumber)
+          return { data: currentControlIssue }
+        },
+        getLabel: async () => ({ data: {} }),
+        listComments: async () => {},
+      },
+      pulls: {
+        create: async (input) => {
+          calls.createdPullRequests.push(input)
+          return {
+            data: {
+              ...releasePullRequest,
+              head: { ...releasePullRequest.head, ref: input.head },
+            },
+          }
+        },
+        get: async () => ({ data: currentPullRequest }),
+        list: async () => ({ data: openPullRequests }),
+        merge: async (input) => {
+          calls.merges.push(input)
+          return { data: { merged: true, sha: mergeSha } }
+        },
+      },
+      repos: {
+        compareCommitsWithBasehead: async () => ({ data: compare }),
+      },
+    },
+    graphql: async (...input) => calls.graphql.push(input),
+    paginate: async () => comments,
+  }
+  return { calls, github }
+}
+
+function coreRecorder() {
+  const outputs = new Map()
+  return {
+    outputs,
+    core: {
+      info: () => {},
+      warning: () => {},
+      setOutput: (name, value) => outputs.set(name, value),
+    },
+  }
+}
+
+function preparationContext({ association = 'MEMBER', body = '/prepare-production' } = {}) {
+  return {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: { number: controlIssueNumber },
+      comment: { body, author_association: association },
+    },
+  }
+}
+
+function approvalContext({ association = 'MEMBER', body = '/approve-production' } = {}) {
+  return {
+    repo: { owner: 'synupsis', repo: 'synupsis-web' },
+    payload: {
+      issue: { number: releasePullRequest.number, pull_request: {} },
+      comment: { body, author_association: association },
+    },
+  }
+}
+
+test('production commands must match exactly', () => {
+  assert.equal(isPrepareProductionCommand('/prepare-production'), true)
+  assert.equal(isPrepareProductionCommand('/prepare-production '), false)
+  assert.equal(isPrepareProductionCommand('please /prepare-production'), false)
+  assert.equal(isApproveProductionCommand('/approve-production'), true)
+  assert.equal(isApproveProductionCommand('/approve-production\n'), false)
+})
+
+test('preparation freezes develop, opens a draft PR and dispatches release CI', async () => {
+  const { calls, github } = productionGithub()
+  const { core, outputs } = coreRecorder()
+  await handleProductionPreparation({
+    github,
+    context: preparationContext(),
+    core,
+    now: new Date('2026-07-21T12:00:00.000Z'),
+  })
+
+  assert.deepEqual(calls.createdRefs, [{
+    owner: 'synupsis',
+    repo: 'synupsis-web',
+    ref: `refs/heads/${releaseBranch}`,
+    sha: headSha,
+  }])
+  assert.equal(calls.createdPullRequests.length, 1)
+  assert.equal(calls.createdPullRequests[0].base, 'main')
+  assert.equal(calls.createdPullRequests[0].head, releaseBranch)
+  assert.equal(calls.createdPullRequests[0].draft, true)
+  assert.match(calls.createdPullRequests[0].body, new RegExp(releaseHeadMarker(headSha)))
+  assert.match(calls.createdPullRequests[0].body, new RegExp(releaseBaseMarker(baseSha)))
+  assert.deepEqual(calls.addedLabels[0].labels, [
+    'ai:release-candidate',
+    'ai:release-db-changes',
+  ])
+  assert.deepEqual(calls.dispatches, [{
+    owner: 'synupsis',
+    repo: 'synupsis-web',
+    workflow_id: 'ci.yml',
+    ref: releaseBranch,
+  }])
+  assert.equal(outputs.get('preparation_status'), 'ai:release-candidate')
+  assert.equal(outputs.get('head_sha'), headSha)
+  assert.equal(outputs.get('base_sha'), baseSha)
+})
+
+test('untrusted preparation is rejected before repository writes', async () => {
+  const { calls, github } = productionGithub()
+  const { core, outputs } = coreRecorder()
+  await handleProductionPreparation({
+    github,
+    context: preparationContext({ association: 'NONE' }),
+    core,
+  })
+
+  assert.equal(outputs.get('preparation_status'), 'rejected')
+  assert.equal(calls.createdRefs.length, 0)
+  assert.equal(calls.createdPullRequests.length, 0)
+})
+
+test('release checks require a successful run on the exact immutable branch', async () => {
+  const { github } = productionGithub()
+  const checks = await verifyReleaseChecks({
+    github,
+    owner: 'synupsis',
+    repo: 'synupsis-web',
+    pullRequest: releasePullRequest,
+  })
+  assert.match(checks.workflowUrl, /actions\/runs\/100/)
+
+  const wrongBranch = productionGithub({
+    workflowRuns: successfulWorkflowRuns().map((run) => ({
+      ...run,
+      head_branch: 'develop',
+    })),
+  })
+  await assert.rejects(
+    verifyReleaseChecks({
+      github: wrongBranch.github,
+      owner: 'synupsis',
+      repo: 'synupsis-web',
+      pullRequest: releasePullRequest,
+    }),
+    /successful CI workflow run for its release branch/,
+  )
+})
+
+test('approval is bound to trusted metadata, current main and current release SHA', async () => {
+  const { calls, github } = productionGithub()
+  const { core, outputs } = coreRecorder()
+  await handleProductionApproval({ github, context: approvalContext(), core })
+
+  assert.equal(outputs.get('approval_status'), 'ai:release-approved')
+  assert.equal(outputs.get('pull_request_number'), '31')
+  assert.equal(outputs.get('head_sha'), headSha)
+  assert.equal(outputs.get('base_sha'), baseSha)
+  assert.deepEqual(calls.addedLabels[0].labels, ['ai:release-approved'])
+  assert.match(calls.comments[0].body, new RegExp(releaseHeadMarker(headSha)))
+  assert.match(calls.comments[0].body, new RegExp(releaseBaseMarker(baseSha)))
+
+  const staleMain = productionGithub({ mainSha: 'e'.repeat(40) })
+  await assert.rejects(
+    handleProductionApproval({
+      github: staleMain.github,
+      context: approvalContext(),
+      core,
+    }),
+    /main changed after Pull Request/,
+  )
+})
+
+test('metadata from an arbitrary bot cannot authorize a production release', async () => {
+  const untrustedMetadata = {
+    ...metadataComment,
+    user: { type: 'Bot', login: 'some-app[bot]' },
+  }
+  const { github } = productionGithub({ comments: [untrustedMetadata] })
+  const { core } = coreRecorder()
+  await assert.rejects(
+    handleProductionApproval({ github, context: approvalContext(), core }),
+    /no trusted release metadata/,
+  )
+})
+
+test('approved production uses a merge commit and revalidates all immutable values', async () => {
+  const { calls, github } = productionGithub({ comments: [metadataComment, approvalComment] })
+  const { core, outputs } = coreRecorder()
+  await mergeApprovedProduction({
+    github,
+    context: { repo: { owner: 'synupsis', repo: 'synupsis-web' } },
+    core,
+    pullRequestNumber: releasePullRequest.number,
+    expectedHeadSha: headSha,
+    expectedBaseSha: baseSha,
+  })
+
+  assert.equal(calls.graphql.length, 1)
+  assert.equal(calls.merges.length, 1)
+  assert.equal(calls.merges[0].sha, headSha)
+  assert.equal(calls.merges[0].merge_method, 'merge')
+  assert.deepEqual(calls.deletedRefs.map((call) => call.ref), [`heads/${releaseBranch}`])
+  assert.equal(outputs.get('promotion_status'), 'ai:production-promoted')
+  assert.equal(outputs.get('merge_sha'), mergeSha)
+  assert.match(calls.comments.at(-1).body, /Vérifier maintenant les déploiements/)
+})
+
+test('merge refuses a release whose recorded approval no longer matches', async () => {
+  const { github } = productionGithub({ comments: [metadataComment, approvalComment] })
+  const { core } = coreRecorder()
+  await assert.rejects(
+    mergeApprovedProduction({
+      github,
+      context: { repo: { owner: 'synupsis', repo: 'synupsis-web' } },
+      core,
+      pullRequestNumber: releasePullRequest.number,
+      expectedHeadSha: 'f'.repeat(40),
+      expectedBaseSha: baseSha,
+    }),
+    /changed during production approval/,
+  )
+})

--- a/.github/scripts/workflow-permissions.test.mjs
+++ b/.github/scripts/workflow-permissions.test.mjs
@@ -31,3 +31,26 @@ test('automated AI reviews trust only the GitHub Actions bot', () => {
   assert.match(reviewJob, /^          allow-bot-users: 'github-actions\[bot\]'$/m)
   assert.doesNotMatch(reviewJob, /^          allow-bots: true$/m)
 })
+
+test('production release separates approval from the final merge permission', () => {
+  const workflow = '.github/workflows/production-release.yml'
+  const source = readFileSync(workflow, 'utf8')
+  const prepareJob = workflowJob(workflow, 'prepare')
+  const authorizeJob = workflowJob(workflow, 'authorize')
+  const mergeJob = workflowJob(workflow, 'merge')
+
+  assert.match(source, /^permissions: \{\}$/m)
+  assert.match(source, /^  group: production-release$/m)
+  assert.match(prepareJob, /^      actions: write$/m)
+  assert.match(prepareJob, /^      contents: write$/m)
+  assert.match(authorizeJob, /^      actions: read$/m)
+  assert.match(authorizeJob, /^      checks: read$/m)
+  assert.match(authorizeJob, /^      contents: read$/m)
+  assert.doesNotMatch(authorizeJob, /^      contents: write$/m)
+  assert.match(mergeJob, /^      contents: write$/m)
+  assert.match(mergeJob, /needs\.authorize\.outputs\.approval_status == 'ai:release-approved'/)
+
+  for (const job of [prepareJob, authorizeJob, mergeJob]) {
+    assert.match(job, /^          persist-credentials: false$/m)
+  }
+})

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,0 +1,124 @@
+name: Production release
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: {}
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare an immutable production candidate
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/prepare-production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout trusted pipeline code from develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Freeze develop and open the release Pull Request
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/production-release.mjs`,
+            )
+            const { handleProductionPreparation } = await import(moduleUrl.href)
+            await handleProductionPreparation({ github, context, core })
+
+  authorize:
+    name: Validate and record the production approval
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/approve-production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      approval_status: ${{ steps.authorize.outputs.approval_status }}
+      pull_request_number: ${{ steps.authorize.outputs.pull_request_number }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
+      base_sha: ${{ steps.authorize.outputs.base_sha }}
+
+    steps:
+      - name: Checkout trusted pipeline code from develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Revalidate and record the approval
+        id: authorize
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/production-release.mjs`,
+            )
+            const { handleProductionApproval } = await import(moduleUrl.href)
+            await handleProductionApproval({ github, context, core })
+
+  merge:
+    name: Promote the approved candidate into main
+    needs: authorize
+    if: needs.authorize.outputs.approval_status == 'ai:release-approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout trusted pipeline code from develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Revalidate and merge the approved release
+        uses: actions/github-script@v9
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.authorize.outputs.pull_request_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/production-release.mjs`,
+            )
+            const { mergeApprovedProduction } = await import(moduleUrl.href)
+            await mergeApprovedProduction({
+              github,
+              context,
+              core,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
+              expectedBaseSha: process.env.EXPECTED_BASE_SHA,
+            })

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Run Edge Functions locally
 
 ## Deployment
 
-The `develop` branch is automatically deployed to the shared development environment on Netlify. Pull requests get an isolated Netlify Deploy Preview.
+The `develop` branch is automatically deployed to the shared development environment on Netlify. Pull requests get an isolated Netlify Deploy Preview. The `main` branch is reserved for the separate Netlify and Supabase production projects.
 
-After testing a generated Pull Request's Deploy Preview, an authorized repository member can approve it with `/approve-preview`. The pipeline then squash-merges it into `develop` only. No automatic production deployment is configured yet.
+After testing a generated Pull Request's Deploy Preview, an authorized repository member can approve it with `/approve-preview`. The pipeline then squash-merges it into `develop` only.
+
+Production uses a second, explicit gate: `/prepare-production` freezes the current `develop` SHA into a draft release Pull Request targeting `main`; `/approve-production` revalidates that immutable SHA, the recorded `main` base and release CI before merging with a merge commit. External Netlify and Supabase deployments must still be checked after the merge.
 
 ## AI feature pipeline
 

--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -1,8 +1,8 @@
 # Pipeline IA Synupsis
 
-Le pipeline permet à un membre non développeur de proposer une fonctionnalité, de faire produire et reviewer son implémentation, puis de tester une Deploy Preview avant son intégration dans l’environnement de développement partagé.
+Le pipeline permet à un membre non développeur de proposer une fonctionnalité, de faire produire et reviewer son implémentation, puis de tester une Deploy Preview avant son intégration dans l’environnement de développement partagé. Une procédure séparée permet ensuite de préparer et d’approuver explicitement un lot de changements pour la production.
 
-La production n’est pas encore configurée. Aucune commande décrite ici ne déploie sur `main` ou en production.
+Les projets Netlify et Supabase de production sont distincts de leurs équivalents de développement. La promotion reste désactivée tant que l’Issue de contrôle portant `ai:release-control` n’a pas été créée par un membre autorisé.
 
 ## Vue d’ensemble
 
@@ -13,7 +13,9 @@ La production n’est pas encore configurée. Aucune commande décrite ici ne d�
 5. laisser la CI, Netlify et l’agent reviewer analyser la proposition ;
 6. si nécessaire, autoriser les corrections avec `/apply-review-fixes` ;
 7. tester manuellement la Deploy Preview Netlify ;
-8. accepter son intégration dans `develop` avec `/approve-preview`.
+8. accepter son intégration dans `develop` avec `/approve-preview` ;
+9. préparer un snapshot de `develop` avec `/prepare-production` ;
+10. vérifier la release puis autoriser sa fusion dans `main` avec `/approve-production`.
 
 ## Étape 1 — Collecte de la demande
 
@@ -124,8 +126,34 @@ yarn test:pipeline
 
 Les workflows de collecte, spécification, développement et review peuvent aussi être relancés manuellement depuis l’onglet **Actions** avec le numéro d’Issue ou de Pull Request demandé. Les commandes `/approve-spec`, `/apply-review-fixes` et `/approve-preview` restent volontairement publiques et humaines afin de conserver une trace d’autorisation explicite.
 
-## Frontière avec la production
+## Promotion vers la production
 
-À ce stade, Netlify déploie automatiquement `develop` vers l’environnement de développement partagé et crée une Deploy Preview pour chaque Pull Request. Aucun environnement GitHub Production, aucun déploiement automatique de `main` et aucune promotion vers la production ne font partie de ce pipeline.
+La production est volontairement séparée de l’acceptation d’une fonctionnalité. `/approve-preview` ne peut fusionner que dans `develop`. Une mise en production regroupe donc tous les commits déjà acceptés dans `develop` mais encore absents de `main`.
 
-La prochaine étape sera de créer une fondation de production séparée : environnement Netlify dédié, secrets et Supabase de production distincts, remise à niveau contrôlée de `main`, règles de protection et commande de promotion indépendante. Cette étape devra conserver une validation humaine supplémentaire et ne réutilisera pas `/approve-preview`.
+Un membre autorisé prépare ce lot en commentant exactement ceci sur l’Issue permanente portant le label `ai:release-control` :
+
+```text
+/prepare-production
+```
+
+Le workflow `Production release` revalide l’auteur et l’Issue, puis :
+
+- lit les SHA courants de `develop` et `main` ;
+- crée une branche immuable `release/<date>-<heure>-<sha>` sur le SHA exact de `develop` ;
+- ouvre une Pull Request brouillon de cette branche vers `main` ;
+- liste les commits, fichiers et changements sensibles, dont les migrations et fonctions Supabase ;
+- déclenche explicitement la CI sur la branche de release.
+
+Cette première commande ne fusionne rien et ne déploie rien. Elle fournit un candidat stable à relire. L’équipe doit notamment vérifier la CI, le fonctionnement actuel de l’environnement de développement partagé et tout changement Supabase signalé dans la PR.
+
+Après cette validation, un membre autorisé peut commenter exactement ceci sur la Pull Request de release :
+
+```text
+/approve-production
+```
+
+Juste avant la fusion, le workflow vérifie de nouveau l’auteur, la provenance de la branche, le SHA figé, le SHA de `main` enregistré lors de la préparation, les métadonnées publiées par GitHub Actions, l’absence de conflit et la réussite de la CI propre à cette branche. Si l’un de ces éléments a changé, la promotion s’arrête et il faut préparer une nouvelle release.
+
+Une release valide est fusionnée dans `main` avec un **merge commit**, sans squash. Netlify et l’intégration Supabase liée à `main` peuvent alors démarrer leurs déploiements. Le commentaire final demande explicitement de vérifier ces deux déploiements et d’effectuer un smoke test sur `https://synupsis.com` : une fusion réussie ne prouve pas à elle seule que la production est saine.
+
+Le projet Supabase gratuit ne fournit pas de branche de preview de base de données. Toute migration doit donc rester rétrocompatible autant que possible, être relue dans la PR de release et avoir une stratégie de retour arrière avant l’approbation. Le déploiement de production Supabase et les règles de protection de `main` doivent être activés avant la première utilisation réelle de `/prepare-production`.


### PR DESCRIPTION
## Résumé

- ajoute `/prepare-production` sur une Issue de contrôle pour figer le SHA courant de `develop` dans une branche `release/*` et ouvrir une PR brouillon vers `main` ;
- ajoute `/approve-production` sur la PR de release pour revalider l’auteur, les SHA de `develop` et `main`, les métadonnées GitHub Actions, les conflits et la CI propre à la branche avant un merge commit ;
- signale les migrations et fonctions Supabase dans le récapitulatif de release ;
- documente la séparation entre preview de développement et promotion en production.

## Sécurité

La préparation et l’approbation exigent des commandes exactes provenant d’un propriétaire, membre ou collaborateur. Les métadonnées et validations sont liées au SHA complet et seuls les commentaires de `github-actions[bot]` sont reconnus. Les permissions d’écriture sont séparées entre préparation, autorisation et fusion.

## Validation

- `yarn test:pipeline` — 58 tests réussis
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- validation syntaxique Node et YAML

## Activation ultérieure

La PR installe le mécanisme mais ne déclenche aucun déploiement. Avant la première release réelle, il restera à protéger `main`, activer le déploiement Supabase de production et créer l’Issue permanente portant le label `ai:release-control`.
